### PR TITLE
Implement a RestaurantPage with Router

### DIFF
--- a/__mocks__/react-router-dom.js
+++ b/__mocks__/react-router-dom.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+};

--- a/__mocks__/react-router-dom.js
+++ b/__mocks__/react-router-dom.js
@@ -1,4 +1,0 @@
-module.exports = {
-  ...jest.requireActual('react-router-dom'),
-  useParams: jest.fn(),
-};

--- a/fixtures/restaurant.js
+++ b/fixtures/restaurant.js
@@ -1,0 +1,63 @@
+const restaurants = {
+  id: 1,
+  categoryId: 1,
+  name: '양천주가',
+  address: '서울 강남구',
+  menuItems: [{ id: 16, restaurantId: 1, name: '탕수육' }, { id: 17, restaurantId: 1, name: '팔보채' }],
+  reviews: [{
+    id: 1, restaurantId: 1, name: '테스터', score: 5, description: '훌륭하다 훌륭하다 지구인놈들',
+  }, {
+    id: 3, restaurantId: 1, name: '테스터', score: 3, description: 'Hi!',
+  }, {
+    id: 6, restaurantId: 1, name: '테스터', score: 1, description: '비룡 어디에 갔냐? 비룡 내놔라.',
+  }, {
+    id: 146, restaurantId: 1, name: '테스터', score: 5, description: 'Good',
+  }, {
+    id: 125, restaurantId: 1, name: '테스터', score: 3, description: '22222222222222',
+  }, {
+    id: 124, restaurantId: 1, name: '테스터', score: 3, description: '444444444',
+  }, {
+    id: 123, restaurantId: 1, name: '테스터', score: 3, description: 'teasfda',
+  }, {
+    id: 122, restaurantId: 1, name: '테스터', score: 3, description: 'zz',
+  }, {
+    id: 19, restaurantId: 1, name: '테스터', score: 3, description: '맛없어요\n노맛돈아깝',
+  }, {
+    id: 121, restaurantId: 1, name: '테스터', score: 3, description: '222222',
+  }, {
+    id: 120, restaurantId: 1, name: '테스터', score: 3, description: 'tet',
+  }, {
+    id: 119, restaurantId: 1, name: '테스터', score: 3, description: 'test',
+  }, {
+    id: 118, restaurantId: 1, name: '테스터', score: 3, description: 'test',
+  }, {
+    id: 117, restaurantId: 1, name: '테스터', score: 3, description: 'tr',
+  }, {
+    id: 147, restaurantId: 1, name: '테스터', score: 5, description: 'GOOOOOOODDDDD!!!!!',
+  }, {
+    id: 177, restaurantId: 1, name: '테스터', score: 5, description: 'asdf',
+  }, {
+    id: 182, restaurantId: 1, name: '관리자', score: 3, description: 'rsdfw',
+  }, {
+    id: 186, restaurantId: 1, name: '테스터', score: 3, description: 'Final',
+  }, {
+    id: 187, restaurantId: 1, name: '테스터', score: 1, description: '흠',
+  }, {
+    id: 188, restaurantId: 1, name: '테스터', score: 5, description: '완벽해요!',
+  }, {
+    id: 189, restaurantId: 1, name: '테스터', score: 2, description: 'TWO',
+  }, {
+    id: 190, restaurantId: 1, name: '테스터', score: 1, description: '111',
+  }, {
+    id: 191, restaurantId: 1, name: '테스터', score: 1, description: '1점 테스트',
+  }, {
+    id: 193, restaurantId: 1, name: '테스터', score: 2, description: '2점을 넣으면?',
+  }, {
+    id: 194, restaurantId: 1, name: '테스터', score: 3, description: '무난해요',
+  }, {
+    id: 195, restaurantId: 1, name: '테스터', score: 5, description: '최고!',
+  }],
+  information: '양천주가 in 서울 강남구',
+};
+
+export default restaurants;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="main.js"></script>
+    <script src="/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="/main.js"></script>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6397,6 +6397,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -9304,6 +9317,15 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10790,6 +10812,52 @@
         "react-is": "^16.9.0"
       }
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -11170,6 +11238,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12698,6 +12771,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13124,6 +13207,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,13 +1723,22 @@
       }
     },
     "@testing-library/react": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.3.tgz",
-      "integrity": "sha512-A/ydYXcwAcfY7vkPrfUkUTf9HQLL3/GtixTefcu3OyGQtAYQ7XBQj1S9FWbLEhfWa0BLwFwTBFS3Ao1O0tbMJg==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.4.tgz",
+      "integrity": "sha512-SKDQ2jBdg9UQQYQragkvXOzNp4hnCdOvXyZ52rg+OXiiumVxkAutdvvRzBF4PrbvMQ27Z6gx0GVo2YQ1Mcip8g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.3",
-        "@testing-library/dom": "^7.17.1"
+        "@testing-library/dom": "^7.17.1",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "@types/aria-query": {
@@ -1771,9 +1780,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.12.tgz",
-      "integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
+      "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1790,9 +1799,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -1862,9 +1871,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
+      "version": "14.0.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.18.tgz",
+      "integrity": "sha512-0Z3nS5acM0cIV4JPzrj9g/GH0Et5vmADWtip3YOXOp1NpOLU8V3KoZDc8ny9c1pe/YSYYzQkAWob6dyV/EWg4g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1873,9 +1882,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
-      "integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
       "dev": true
     },
     "@types/request": {
@@ -2826,16 +2835,6 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true,
       "optional": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bl": {
       "version": "4.0.2",
@@ -4322,9 +4321,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.488",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.488.tgz",
-      "integrity": "sha512-NReBdOugu1yl8ly+0VDtiQ6Yw/1sLjnvflWq0gvY1nfUXU2PbA+1XAVuEb7ModnwL/MfUPjby7e4pAFnSHiy6Q==",
+      "version": "1.3.490",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.490.tgz",
+      "integrity": "sha512-jKJF1mKXrQkT0ZiuJ/oV63Q02hAeWz0GGt/z6ryc518uCHtMyS9+wYAysZtBQ8rsjqFPAYXV4TIz5GQ8xyubPA==",
       "dev": true
     },
     "elliptic": {
@@ -5445,6 +5444,12 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -5655,13 +5660,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
       "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -9638,13 +9636,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10311,10 +10302,19 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -10827,21 +10827,6 @@
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
       }
     },
     "react-router-dom": {
@@ -12601,9 +12586,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
       "requires": {
         "bl": "^4.0.1",
         "end-of-stream": "^1.4.1",
@@ -13410,11 +13395,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -14019,11 +14000,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,6 +1741,11 @@
         }
       }
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+    },
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
@@ -1816,6 +1821,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/html-minifier-terser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
+      "integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -1898,11 +1908,21 @@
         "form-data": "^2.5.0"
       }
     },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA=="
     },
     "@types/testing-library__jest-dom": {
       "version": "5.9.1",
@@ -1917,6 +1937,58 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+    },
+    "@types/uglify-js": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.21",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
+      "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.0.tgz",
+      "integrity": "sha512-c88dKrpSle9BtTqR6ifdaxu1Lvjsl3C5OsfvuUbUwdXymshv1TkufUAXBajCCUM/f/TmnkZC/Esb03MinzSiXQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
     },
     "@types/yargs": {
       "version": "15.0.5",
@@ -2826,8 +2898,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -2924,6 +2995,11 @@
         "multicast-dns": "^6.0.1",
         "multicast-dns-service-types": "^1.1.0"
       }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3088,8 +3164,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -3177,6 +3252,15 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camel-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "requires": {
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -3305,6 +3389,21 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -3529,8 +3628,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -3902,6 +4000,17 @@
         }
       }
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
     "css-to-xpath": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/css-to-xpath/-/css-to-xpath-0.1.0.tgz",
@@ -3916,6 +4025,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
       "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo="
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "css.escape": {
       "version": "1.5.1",
@@ -4058,7 +4172,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -4235,11 +4348,40 @@
       "integrity": "sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==",
       "dev": true
     },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "requires": {
+        "utila": "~0.4"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        }
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -4256,6 +4398,32 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
       }
     },
     "duplexer": {
@@ -4358,8 +4526,7 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4413,6 +4580,11 @@
         }
       }
     },
+    "entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+    },
     "envinfo": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
@@ -4447,7 +4619,6 @@
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -4466,7 +4637,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -6068,8 +6238,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -6275,7 +6444,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -6305,8 +6473,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6392,8 +6559,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "history": {
       "version": "4.10.1",
@@ -6491,6 +6657,63 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        }
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz",
+      "integrity": "sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==",
+      "requires": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.15",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -6981,8 +7204,7 @@
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-      "dev": true
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -7016,8 +7238,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -7127,7 +7348,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
       "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -7148,7 +7368,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -8966,7 +9185,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -8977,7 +9195,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -9131,6 +9348,14 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "requires": {
+        "tslib": "^1.10.0"
       }
     },
     "lru-cache": {
@@ -9347,8 +9572,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -9685,6 +9909,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -9851,6 +10084,14 @@
         "path-key": "^2.0.0"
       }
     },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -9901,8 +10142,7 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
       "version": "1.1.2",
@@ -9917,8 +10157,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -9933,7 +10172,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -9968,7 +10206,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -10194,6 +10431,15 @@
         }
       }
     },
+    "param-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10253,6 +10499,15 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -10480,6 +10735,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
     },
     "pretty-format": {
       "version": "25.5.0",
@@ -11060,11 +11324,43 @@
         }
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -12006,7 +12302,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -12015,8 +12310,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -12433,7 +12727,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -12443,7 +12736,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -12570,8 +12862,7 @@
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar-fs": {
       "version": "2.1.0",
@@ -12628,7 +12919,6 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
       "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-      "dev": true,
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -12638,8 +12928,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -12884,8 +13173,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -13146,6 +13434,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
+    "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@codeceptjs/configure": "^0.5.2",
+    "html-webpack-plugin": "^4.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",

--- a/src/AboutPage.jsx
+++ b/src/AboutPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function AboutPage() {
+  return (
+    <div>
+      <h2>About</h2>
+    </div>
+  );
+}

--- a/src/AboutPage.jsx
+++ b/src/AboutPage.jsx
@@ -4,6 +4,7 @@ export default function AboutPage() {
   return (
     <div>
       <h2>About</h2>
+      <p>This is ....</p>
     </div>
   );
 }

--- a/src/AboutPage.test.jsx
+++ b/src/AboutPage.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import AboutPage from './AboutPage';
+
+test('AboutPage', () => {
+  const { container } = render(<AboutPage />);
+
+  expect(container).toHaveTextContent('About');
+});

--- a/src/AboutPage.test.jsx
+++ b/src/AboutPage.test.jsx
@@ -4,8 +4,16 @@ import { render } from '@testing-library/react';
 
 import AboutPage from './AboutPage';
 
-test('AboutPage', () => {
-  const { container } = render(<AboutPage />);
+describe('<AboutPage />', () => {
+  it('shows page name', () => {
+    const { container } = render(<AboutPage />);
 
-  expect(container).toHaveTextContent('About');
+    expect(container).toHaveTextContent('About');
+  });
+
+  it('shows page content', () => {
+    const { container } = render(<AboutPage />);
+
+    expect(container).toHaveTextContent('This is ....');
+  });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,12 +40,19 @@ import NotFoundPage from './NotFoundPage';
 
 export default function App() {
   return (
-    <Switch>
-      <Route exact path="/" component={HomePage} />
-      <Route path="/about" component={AboutPage} />
-      <Route path="/restaurants" component={RestaurantsPage} />
-      <Route path="/restaurant/:restaurantId" component={RestaurantPage} />
-      <Route path="/non-existent" component={NotFoundPage} />
-    </Switch>
+    <div>
+      <header>
+        헤더
+      </header>
+      <Switch>
+        <Route exact path="/" component={HomePage} />
+        <Route path="/about" component={AboutPage} />
+        <Route path="/restaurants" component={RestaurantsPage} />
+        <Route path="/restaurant/:restaurantId" component={RestaurantPage} />
+        <Route path="/non-existent" component={NotFoundPage} />
+      </Switch>
+
+    </div>
+
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Switch, Route } from 'react-router-dom';
 
+import RestaurantsPage from './RestaurantsPage';
+
 // 0. 지역, 분류 목록을 얻기
 // 1. 지역 선택 - Regions <- API (0)
 // 2. 분류 선택 - Categories - 한식, 중식, 일식, ... <- API (0)
@@ -48,6 +50,7 @@ export default function App() {
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/about" component={AboutPage} />
+      <Route path="/restaurants" component={RestaurantsPage} />
       {/* <RestaurantsPage />
       <RestaurantPage />
       <NotFoundPage /> */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useDispatch } from 'react-redux';
-
-import RegionsContainer from './RegionsContainer';
-import CategoriesContainer from './CategoriesContainer';
-import RestaurantsContainer from './RestaurantsContainer';
-
-import {
-  loadInitialData,
-} from './actions';
+import { Switch, Route } from 'react-router-dom';
 
 // 0. 지역, 분류 목록을 얻기
 // 1. 지역 선택 - Regions <- API (0)
@@ -37,20 +29,22 @@ import {
  * 6. NotFoundPage
  * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
- */
+*/
+
+function HomePage() {
+  return (
+    <h2>Home</h2>
+  );
+}
 
 export default function App() {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(loadInitialData());
-  });
-
   return (
-    <div>
-      <RegionsContainer />
-      <CategoriesContainer />
-      <RestaurantsContainer />
-    </div>
+    <Switch>
+      <Route exact path="/" component={HomePage} />
+      {/* <AboutPage />
+      <RestaurantsPage />
+      <RestaurantPage />
+      <NotFoundPage /> */}
+    </Switch>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import HomePage from './HomePage';
+import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
 
 // 0. 지역, 분류 목록을 얻기
@@ -33,12 +34,6 @@ import RestaurantsPage from './RestaurantsPage';
  * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
 */
-
-function AboutPage() {
-  return (
-    <h2>About</h2>
-  );
-}
 
 function NotFoundPage() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { Switch, Route } from 'react-router-dom';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
+import NotFoundPage from './NotFoundPage';
 
 // 0. 지역, 분류 목록을 얻기
 // 1. 지역 선택 - Regions <- API (0)
@@ -34,12 +35,6 @@ import RestaurantsPage from './RestaurantsPage';
  * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
 */
-
-function NotFoundPage() {
-  return (
-    <h2>404 Not Found</h2>
-  );
-}
 
 export default function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,15 +45,20 @@ function AboutPage() {
   );
 }
 
+function NotFoundPage() {
+  return (
+    <h2>404 Not Found</h2>
+  );
+}
+
 export default function App() {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/about" component={AboutPage} />
       <Route path="/restaurants" component={RestaurantsPage} />
-      {/* <RestaurantsPage />
-      <RestaurantPage />
-      <NotFoundPage /> */}
+      {/* <RestaurantPage /> */}
+      <Route path="/non-existent" component={NotFoundPage} />
     </Switch>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { Switch, Route } from 'react-router-dom';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
+import RestaurantPage from './RestaurantPage';
 import NotFoundPage from './NotFoundPage';
 
 // 0. 지역, 분류 목록을 얻기
@@ -26,7 +27,8 @@ import NotFoundPage from './NotFoundPage';
  * - 관련 내용("About...")이 보인다.
  * 4. RestaurantsPage
  * - 페이지 이름("Restaurants")이 보인다. (임의로 추가함)
- * - 지역과 카테고리를 모두 선택하면, 레스토랑 목록이 보인다.
+ * - 지역과 카테고리를 모두 선택하면, 레스토랑 목록이 보인
+ * 다.
  * - 레스토랑을 클릭하면, 레스토랑 상세 페이지로 이동한다.
  * 5. RestaurantPage
  * - 페이지 이름("Restaurant")이 보인다. (임의로 추가함)
@@ -36,19 +38,13 @@ import NotFoundPage from './NotFoundPage';
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
 */
 
-function RestaurantPage() {
-  return (
-    <h2>Restaurant</h2>
-  );
-}
-
 export default function App() {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/about" component={AboutPage} />
       <Route path="/restaurants" component={RestaurantsPage} />
-      <Route path="/restaurant" component={RestaurantPage} />
+      <Route path="/restaurant/:restaurantId" component={RestaurantPage} />
       <Route path="/non-existent" component={NotFoundPage} />
     </Switch>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,7 +49,7 @@ export default function App() {
         <Route path="/about" component={AboutPage} />
         <Route exact path="/restaurants" component={RestaurantsPage} />
         <Route path="/restaurants/:restaurantId" component={RestaurantPage} />
-        <Route path="/any_not_exist_url" component={NotFoundPage} />
+        <Route component={NotFoundPage} />
       </Switch>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Link } from 'react-router-dom';
 
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
@@ -42,7 +42,7 @@ export default function App() {
   return (
     <div>
       <header>
-        헤더
+        <Link to="/"><h1>헤더</h1></Link>
       </header>
       <Switch>
         <Route exact path="/" component={HomePage} />
@@ -51,8 +51,6 @@ export default function App() {
         <Route path="/restaurant/:restaurantId" component={RestaurantPage} />
         <Route path="/non-existent" component={NotFoundPage} />
       </Switch>
-
     </div>
-
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,12 +37,18 @@ function HomePage() {
   );
 }
 
+function AboutPage() {
+  return (
+    <h2>About</h2>
+  );
+}
+
 export default function App() {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
-      {/* <AboutPage />
-      <RestaurantsPage />
+      <Route path="/about" component={AboutPage} />
+      {/* <RestaurantsPage />
       <RestaurantPage />
       <NotFoundPage /> */}
     </Switch>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,11 +20,11 @@ import { Switch, Route } from 'react-router-dom';
  * - 페이지 이름("About")이 보인다.
  * - 관련 내용("About...")이 보인다.
  * 4. RestaurantsPage
- * - 페이지 이름("RestaurantsList")이 보인다. (임의로 추가함)
+ * - 페이지 이름("Restaurants")이 보인다. (임의로 추가함)
  * - 지역과 카테고리를 모두 선택하면, 레스토랑 목록이 보인다.
  * - 레스토랑을 클릭하면, 레스토랑 상세 페이지로 이동한다.
  * 5. RestaurantPage
- * - 페이지 이름("RestaurantsDetail")이 보인다. (임의로 추가함)
+ * - 페이지 이름("Restaurant")이 보인다. (임의로 추가함)
  * - 레스토랑에 대한 정보들(이름, 주소, 메뉴 목록)이 보인다.
  * 6. NotFoundPage
  * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,30 @@ import {
 // 2. 분류 선택 - Categories - 한식, 중식, 일식, ... <- API (0)
 // 3. 식당 목록 - Restaurants <- API (with region, category) -> 1, 2 모두 완료된 경우
 
+/**
+ * # 레스토랑 시스템 웹
+ * 1. Header
+ * - 페이지 이름("헤더")이 보인다.
+ * - 어느 페이지(/restaurants, /about, /non-exist)에서든, 헤더를 클릭하면 메이 페이지로 이동한다.
+ * 2. HomePage
+ * - 페이지 이름("Home")이 보인다.
+ * - 메뉴들(About, Restaurants)이 보인다.
+ * - 메뉴를 클릭하면, 해당 메뉴 페이지로 이동한다.
+ * 3. AboutPage
+ * - 페이지 이름("About")이 보인다.
+ * - 관련 내용("About...")이 보인다.
+ * 4. RestaurantsPage
+ * - 페이지 이름("RestaurantsList")이 보인다. (임의로 추가함)
+ * - 지역과 카테고리를 모두 선택하면, 레스토랑 목록이 보인다.
+ * - 레스토랑을 클릭하면, 레스토랑 상세 페이지로 이동한다.
+ * 5. RestaurantPage
+ * - 페이지 이름("RestaurantsDetail")이 보인다. (임의로 추가함)
+ * - 레스토랑에 대한 정보들(이름, 주소, 메뉴 목록)이 보인다.
+ * 6. NotFoundPage
+ * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)
+ * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
+ */
+
 export default function App() {
   const dispatch = useDispatch();
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Switch, Route } from 'react-router-dom';
 
+import HomePage from './HomePage';
 import RestaurantsPage from './RestaurantsPage';
 
 // 0. 지역, 분류 목록을 얻기
@@ -32,12 +33,6 @@ import RestaurantsPage from './RestaurantsPage';
  * - 페이지 이름("404 Not Found")이 보인다. (임의로 추가함)
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
 */
-
-function HomePage() {
-  return (
-    <h2>Home</h2>
-  );
-}
 
 function AboutPage() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,13 +36,19 @@ import NotFoundPage from './NotFoundPage';
  * - 존재하지 않는 URL로 접근했을 때, 404 Not Found 페이지가 보인다.
 */
 
+function RestaurantPage() {
+  return (
+    <h2>Restaurant</h2>
+  );
+}
+
 export default function App() {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/about" component={AboutPage} />
       <Route path="/restaurants" component={RestaurantsPage} />
-      {/* <RestaurantPage /> */}
+      <Route path="/restaurant" component={RestaurantPage} />
       <Route path="/non-existent" component={NotFoundPage} />
     </Switch>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,9 +47,9 @@ export default function App() {
       <Switch>
         <Route exact path="/" component={HomePage} />
         <Route path="/about" component={AboutPage} />
-        <Route path="/restaurants" component={RestaurantsPage} />
-        <Route path="/restaurant/:restaurantId" component={RestaurantPage} />
-        <Route path="/non-existent" component={NotFoundPage} />
+        <Route exact path="/restaurants" component={RestaurantsPage} />
+        <Route path="/restaurants/:restaurantId" component={RestaurantPage} />
+        <Route path="/any_not_exist_url" component={NotFoundPage} />
       </Switch>
     </div>
   );

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -32,3 +32,9 @@ test('App', () => {
   expect(queryByText('서울')).not.toBeNull();
   expect(queryByText('한식')).not.toBeNull();
 });
+
+test('App with router', () => {
+  it('render a different page according to URL', () => {
+
+  });
+});

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -49,15 +49,18 @@ describe('App with router', () => {
     });
   });
 
+  // TODO : 파라미터에 따라 다른 콘텐츠 보여주는 거 공부 후 구현하기
   // context('with URL included /RestaurantPage', () => {
   //   it('shows page name', () => {
 
   //   });
   // });
 
-  // context('with URL included /NotFoundPage', () => {
-  //   it('shows page name', () => {
+  context('with URL included /nonExistentPage', () => {
+    it('shows Not Found', () => {
+      const { container } = renderApp({ path: '/codesoom' });
 
-  //   });
-  // });
+      expect(container).toHaveTextContent('404 Not Found');
+    });
+  });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,6 +8,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import App from './App';
 
+import restaurants from '../fixtures/restaurants';
 import restaurant from '../fixtures/restaurant';
 
 jest.mock('react-router-dom');
@@ -40,16 +41,18 @@ describe('App with router', () => {
   });
 
   context('with URL included /RestaurantsPage', () => {
-    it('shows header and page name', () => {
+    const dispatch = jest.fn();
+
+    beforeEach(() => {
       useSelector.mockImplementation((selector) => selector({
         regions: [],
         categories: [],
-        restaurants: [],
+        restaurants,
       }));
-      const dispatch = jest.fn();
-
       useDispatch.mockImplementation(() => dispatch);
+    });
 
+    it('shows header and page name', () => {
       const { container } = renderApp({ path: '/restaurants' });
 
       expect(container).toHaveTextContent('헤더');
@@ -61,11 +64,14 @@ describe('App with router', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {
-      useDispatch.mockImplementation(() => dispatch);
       useParams.mockReturnValue({ restaurantId: 1 });
       useSelector.mockImplementation((selector) => selector({
+        regions: [],
+        categories: [],
+        restaurants,
         restaurant,
       }));
+      useDispatch.mockImplementation(() => dispatch);
     });
 
     it('shows header and page name', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -20,7 +20,7 @@ function renderApp({ path }) {
 }
 
 describe('App with router', () => {
-  context('with URL included /', () => {
+  context('with path /', () => {
     it('shows header and page name', () => {
       const { container } = renderApp({ path: '/' });
 
@@ -29,7 +29,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /about', () => {
+  context('with path /about', () => {
     it('shows header and page name', () => {
       const { container } = renderApp({ path: '/about' });
 
@@ -38,7 +38,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /restaurants', () => {
+  context('with path /restaurants', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {
@@ -58,7 +58,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /restaurants/:restaurantId', () => {
+  context('with path /restaurants/:restaurantId', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -17,23 +17,25 @@ function renderApp({ path }) {
 
 describe('App with router', () => {
   context('with URL included /HomePage', () => {
-    it('shows page name', () => {
+    it('shows header and page name', () => {
       const { container } = renderApp({ path: '/' });
 
+      expect(container).toHaveTextContent('헤더');
       expect(container).toHaveTextContent('Home');
     });
   });
 
   context('with URL included /AboutPage', () => {
-    it('shows page name', () => {
+    it('shows header and page name', () => {
       const { container } = renderApp({ path: '/about' });
 
+      expect(container).toHaveTextContent('헤더');
       expect(container).toHaveTextContent('About');
     });
   });
 
   context('with URL included /RestaurantsPage', () => {
-    it('shows page name', () => {
+    it('shows header and page name', () => {
       useSelector.mockImplementation((selector) => selector({
         regions: [],
         categories: [],
@@ -45,14 +47,16 @@ describe('App with router', () => {
 
       const { container } = renderApp({ path: '/restaurants' });
 
+      expect(container).toHaveTextContent('헤더');
       expect(container).toHaveTextContent('Restaurants');
     });
   });
 
   context('with URL included /RestaurantPage', () => {
-    it('shows page name', () => {
+    it('shows header and page name', () => {
       const { container } = renderApp({ path: '/restaurant/1' });
 
+      expect(container).toHaveTextContent('헤더');
       expect(container).toHaveTextContent('Restaurant1');
     });
   });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -51,11 +51,9 @@ describe('App with router', () => {
 
   context('with URL included /RestaurantPage', () => {
     it('shows page name', () => {
-      const { container } = renderApp({ path: '/restaurant' });
+      const { container } = renderApp({ path: '/restaurant/1' });
 
-      expect(container).toHaveTextContent('Restaurant');
-
-      // TODO : 파라미터에 따라 다른 콘테츠 보여주기
+      expect(container).toHaveTextContent('Restaurant1');
     });
   });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -31,11 +31,13 @@ describe('App with router', () => {
     });
   });
 
-  // context('with URL included /RestaurantsPage', () => {
-  //   it('shows page name', () => {
+  context('with URL included /RestaurantsPage', () => {
+    it('shows page name', () => {
+      const { container } = renderApp({ path: '/restaurants' });
 
-  //   });
-  // });
+      expect(container).toHaveTextContent('Restaurants');
+    });
+  });
 
   // context('with URL included /RestaurantPage', () => {
   //   it('shows page name', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -58,7 +58,7 @@ describe('App with router', () => {
 
   context('with URL included /nonExistentPage', () => {
     it('shows Not Found', () => {
-      const { container } = renderApp({ path: '/codesoom' });
+      const { container } = renderApp({ path: '/non-existent' });
 
       expect(container).toHaveTextContent('404 Not Found');
     });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,34 +2,15 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
-
-test('App', () => {
-  const dispatch = jest.fn();
-
-  useDispatch.mockImplementation(() => dispatch);
-
-  useSelector.mockImplementation((selector) => selector({
-    regions: [{ id: 1, name: '서울' }],
-    categories: [{ id: 1, name: '한식' }],
-    restaurants: [{ id: 1, name: '마법사주방' }],
-  }));
-
-  const { queryByText } = render(<App />);
-
-  expect(dispatch).toBeCalled();
-
-  expect(queryByText('서울')).not.toBeNull();
-  expect(queryByText('한식')).not.toBeNull();
-});
 
 describe('App with router', () => {
   context('with URL included /HomePage', () => {
     it('shows page name', () => {
       const { container } = render(
-        <MemoryRouter>
+        <MemoryRouter initialEntries={['/']}>
           <App />
         </MemoryRouter>,
       );

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,6 +8,8 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import App from './App';
 
+import restaurant from '../fixtures/restaurant';
+
 jest.mock('react-router-dom');
 
 function renderApp({ path }) {
@@ -56,8 +58,14 @@ describe('App with router', () => {
   });
 
   context('with URL included /RestaurantPage', () => {
+    const dispatch = jest.fn();
+
     beforeEach(() => {
+      useDispatch.mockImplementation(() => dispatch);
       useParams.mockReturnValue({ restaurantId: 1 });
+      useSelector.mockImplementation((selector) => selector({
+        restaurant,
+      }));
     });
 
     it('shows header and page name', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -20,7 +20,7 @@ function renderApp({ path }) {
 }
 
 describe('App with router', () => {
-  context('with URL included /HomePage', () => {
+  context('with URL included /', () => {
     it('shows header and page name', () => {
       const { container } = renderApp({ path: '/' });
 
@@ -29,7 +29,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /AboutPage', () => {
+  context('with URL included /about', () => {
     it('shows header and page name', () => {
       const { container } = renderApp({ path: '/about' });
 
@@ -38,7 +38,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /RestaurantsPage', () => {
+  context('with URL included /restaurants', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {
@@ -58,7 +58,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /RestaurantPage', () => {
+  context('with URL included /restaurants/:restaurantId', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {
@@ -79,7 +79,7 @@ describe('App with router', () => {
     });
   });
 
-  context('with URL included /any_not_exist_url', () => {
+  context('with invalid path', () => {
     it('shows Not Found', () => {
       const { container } = renderApp({ path: '/any_not_exist_url' });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6,14 +6,18 @@ import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
 
+function renderApp({ path }) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
 describe('App with router', () => {
   context('with URL included /HomePage', () => {
     it('shows page name', () => {
-      const { container } = render(
-        <MemoryRouter initialEntries={['/']}>
-          <App />
-        </MemoryRouter>,
-      );
+      const { container } = renderApp({ path: '/' });
 
       expect(container).toHaveTextContent('Home');
     });
@@ -21,11 +25,7 @@ describe('App with router', () => {
 
   context('with URL included /AboutPage', () => {
     it('shows page name', () => {
-      const { container } = render(
-        <MemoryRouter initialEntries={['/about']}>
-          <App />
-        </MemoryRouter>,
-      );
+      const { container } = renderApp({ path: '/about' });
 
       expect(container).toHaveTextContent('About');
     });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { useParams, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -10,8 +10,6 @@ import App from './App';
 
 import restaurants from '../fixtures/restaurants';
 import restaurant from '../fixtures/restaurant';
-
-jest.mock('react-router-dom');
 
 function renderApp({ path }) {
   return render(
@@ -64,7 +62,6 @@ describe('App with router', () => {
     const dispatch = jest.fn();
 
     beforeEach(() => {
-      useParams.mockReturnValue({ restaurantId: 1 });
       useSelector.mockImplementation((selector) => selector({
         regions: [],
         categories: [],

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -19,11 +19,17 @@ describe('App with router', () => {
     });
   });
 
-  // context('with URL included /AboutPage', () => {
-  //   it('shows page name', () => {
+  context('with URL included /AboutPage', () => {
+    it('shows page name', () => {
+      const { container } = render(
+        <MemoryRouter initialEntries={['/about']}>
+          <App />
+        </MemoryRouter>,
+      );
 
-  //   });
-  // });
+      expect(container).toHaveTextContent('About');
+    });
+  });
 
   // context('with URL included /RestaurantsPage', () => {
   //   it('shows page name', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -49,12 +49,15 @@ describe('App with router', () => {
     });
   });
 
-  // TODO : 파라미터에 따라 다른 콘텐츠 보여주는 거 공부 후 구현하기
-  // context('with URL included /RestaurantPage', () => {
-  //   it('shows page name', () => {
+  context('with URL included /RestaurantPage', () => {
+    it('shows page name', () => {
+      const { container } = renderApp({ path: '/restaurant' });
 
-  //   });
-  // });
+      expect(container).toHaveTextContent('Restaurant');
+
+      // TODO : 파라미터에 따라 다른 콘테츠 보여주기
+    });
+  });
 
   context('with URL included /nonExistentPage', () => {
     it('shows Not Found', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -75,16 +75,16 @@ describe('App with router', () => {
     });
 
     it('shows header and page name', () => {
-      const { container } = renderApp({ path: '/restaurant/1' });
+      const { container } = renderApp({ path: '/restaurants/1' });
 
       expect(container).toHaveTextContent('헤더');
       expect(container).toHaveTextContent('Restaurant1');
     });
   });
 
-  context('with URL included /nonExistentPage', () => {
+  context('with URL included /any_not_exist_url', () => {
     it('shows Not Found', () => {
-      const { container } = renderApp({ path: '/non-existent' });
+      const { container } = renderApp({ path: '/any_not_exist_url' });
 
       expect(container).toHaveTextContent('404 Not Found');
     });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -12,20 +12,12 @@ test('App', () => {
   useDispatch.mockImplementation(() => dispatch);
 
   useSelector.mockImplementation((selector) => selector({
-    regions: [
-      { id: 1, name: '서울' },
-    ],
-    categories: [
-      { id: 1, name: '한식' },
-    ],
-    restaurants: [
-      { id: 1, name: '마법사주방' },
-    ],
+    regions: [{ id: 1, name: '서울' }],
+    categories: [{ id: 1, name: '한식' }],
+    restaurants: [{ id: 1, name: '마법사주방' }],
   }));
 
-  const { queryByText } = render((
-    <App />
-  ));
+  const { queryByText } = render(<App />);
 
   expect(dispatch).toBeCalled();
 
@@ -33,8 +25,40 @@ test('App', () => {
   expect(queryByText('한식')).not.toBeNull();
 });
 
-test('App with router', () => {
-  it('render a different page according to URL', () => {
+describe('App with router', () => {
+  context('with URL included /HomePage', () => {
+    it('shows page name', () => {
+      const { container } = render(
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>,
+      );
 
+      expect(container).toHaveTextContent('Home');
+    });
   });
+
+  // context('with URL included /AboutPage', () => {
+  //   it('shows page name', () => {
+
+  //   });
+  // });
+
+  // context('with URL included /RestaurantsPage', () => {
+  //   it('shows page name', () => {
+
+  //   });
+  // });
+
+  // context('with URL included /RestaurantPage', () => {
+  //   it('shows page name', () => {
+
+  //   });
+  // });
+
+  // context('with URL included /NotFoundPage', () => {
+  //   it('shows page name', () => {
+
+  //   });
+  // });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
 
+import { useSelector, useDispatch } from 'react-redux';
 import App from './App';
 
 function renderApp({ path }) {
@@ -33,6 +34,15 @@ describe('App with router', () => {
 
   context('with URL included /RestaurantsPage', () => {
     it('shows page name', () => {
+      useSelector.mockImplementation((selector) => selector({
+        regions: [],
+        categories: [],
+        restaurants: [],
+      }));
+      const dispatch = jest.fn();
+
+      useDispatch.mockImplementation(() => dispatch);
+
       const { container } = renderApp({ path: '/restaurants' });
 
       expect(container).toHaveTextContent('Restaurants');

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { MemoryRouter } from 'react-router-dom';
+import { useParams, MemoryRouter } from 'react-router-dom';
 
 import { useSelector, useDispatch } from 'react-redux';
+
 import App from './App';
+
+jest.mock('react-router-dom');
 
 function renderApp({ path }) {
   return render(
@@ -53,6 +56,10 @@ describe('App with router', () => {
   });
 
   context('with URL included /RestaurantPage', () => {
+    beforeEach(() => {
+      useParams.mockReturnValue({ restaurantId: 1 });
+    });
+
     it('shows header and page name', () => {
       const { container } = renderApp({ path: '/restaurant/1' });
 

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h2>Home</h2>
+    </div>
+  );
+}

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -4,6 +4,10 @@ export default function HomePage() {
   return (
     <div>
       <h2>Home</h2>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/restaurants">Restaurants</a></li>
+      </ul>
     </div>
   );
 }

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 export default function HomePage() {
   return (
     <div>
       <h2>Home</h2>
       <ul>
-        <li><a href="/about">About</a></li>
-        <li><a href="/restaurants">Restaurants</a></li>
+        <li><Link to="/about">About</Link></li>
+        <li><Link to="/restaurants">Restaurants</Link></li>
       </ul>
     </div>
   );

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import HomePage from './HomePage';
 
 describe('<HomePage />', () => {
   context('render HomePage', () => {
     it('show page name & menus', () => {
-      const { container } = render(<HomePage />);
+      const { container } = render(<MemoryRouter><HomePage /></MemoryRouter>);
 
       expect(container).toHaveTextContent('Home');
       expect(container).toHaveTextContent('About');

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import HomePage from './HomePage';
+
+test('HomePage', () => {
+  const { container } = render(<HomePage />);
+
+  expect(container).toHaveTextContent('Home');
+});

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -4,8 +4,14 @@ import { render } from '@testing-library/react';
 
 import HomePage from './HomePage';
 
-test('HomePage', () => {
-  const { container } = render(<HomePage />);
+describe('<HomePage />', () => {
+  context('render HomePage', () => {
+    it('show page name & menus', () => {
+      const { container } = render(<HomePage />);
 
-  expect(container).toHaveTextContent('Home');
+      expect(container).toHaveTextContent('Home');
+      expect(container).toHaveTextContent('About');
+      expect(container).toHaveTextContent('Restaurants');
+    });
+  });
 });

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -9,7 +9,11 @@ import HomePage from './HomePage';
 describe('<HomePage />', () => {
   context('render HomePage', () => {
     it('show page name & menus', () => {
-      const { container } = render(<MemoryRouter><HomePage /></MemoryRouter>);
+      const { container } = render((
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>
+      ));
 
       expect(container).toHaveTextContent('Home');
       expect(container).toHaveTextContent('About');

--- a/src/NotFoundPage.jsx
+++ b/src/NotFoundPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function NotFoundPage() {
+  return (
+    <div>
+      <h2>404 Not Found</h2>
+    </div>
+  );
+}

--- a/src/NotFoundPage.test.jsx
+++ b/src/NotFoundPage.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import NotFoundPage from './NotFoundPage';
+
+test('NotFoundPage', () => {
+  const { container } = render(<NotFoundPage />);
+
+  expect(container).toHaveTextContent('404 Not Found');
+});

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -1,31 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+
+import RestaurantDetail from './RestaurantDetail';
+
+import {
+  loadRestaurant,
+} from './actions';
 
 import { get } from './utils';
 
-export default function RestaurantContainer() {
+export default function RestaurantContainer({ restaurantId }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadRestaurant(restaurantId));
+  }, []);
+
   const restaurant = useSelector(get('restaurant'));
 
-  if (!restaurant) {
-    return <p>식당 정보를 불러오고 있습니다...</p>;
-  }
-
   return (
-    <div>
-      <h3>{restaurant.name}</h3>
-      <p>
-        주소:
-        {restaurant.address}
-      </p>
-      <h3>메뉴</h3>
-      <ul>
-        {
-          restaurant.menuItems.map((menu) => (
-            <li key={menu.id}>{menu.name}</li>
-          ))
-        }
-      </ul>
-    </div>
+    <RestaurantDetail restaurant={restaurant} />
   );
 }

--- a/src/RestaurantContainer.jsx
+++ b/src/RestaurantContainer.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+
+import { get } from './utils';
+
+export default function RestaurantContainer() {
+  const restaurant = useSelector(get('restaurant'));
+
+  if (!restaurant) {
+    return <p>식당 정보를 불러오고 있습니다...</p>;
+  }
+
+  return (
+    <div>
+      <h3>{restaurant.name}</h3>
+      <p>
+        주소:
+        {restaurant.address}
+      </p>
+      <h3>메뉴</h3>
+      <ul>
+        {
+          restaurant.menuItems.map((menu) => (
+            <li key={menu.id}>{menu.name}</li>
+          ))
+        }
+      </ul>
+    </div>
+  );
+}

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import RestaurantContainer from './RestaurantContainer';
+
+import restaurant from '../fixtures/restaurant';
+
+jest.mock('react-redux');
+
+describe('<RestaurantContainer />', () => {
+  context('with restaurant', () => {
+    it('shows restaurant info', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurant,
+      }));
+
+      const { container } = render(<RestaurantContainer />);
+
+      expect(container).toHaveTextContent('Restaurant1');
+      expect(container).toHaveTextContent('양천주가');
+      expect(container).toHaveTextContent(/서울 강남구/i);
+      expect(container).toHaveTextContent(/탕수육/i);
+      expect(container).toHaveTextContent(/팔보채/i);
+    });
+  });
+
+  // context('without restaurant', () => {
+  //   it('shows loading message', () => {
+  //     useSelector.mockImplementation((selector) => selector({
+  //       restaurant: null,
+  //     }));
+
+  //     const { container } = render(<RestaurantContainer />);
+
+  //     expect(dispatch).toBeCalled();
+
+  //     expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
+  //   });
+  // });
+});

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantContainer from './RestaurantContainer';
 
@@ -11,13 +11,19 @@ import restaurant from '../fixtures/restaurant';
 jest.mock('react-redux');
 
 describe('<RestaurantContainer />', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatch.mockImplementation(() => dispatch);
+  });
+
   context('with restaurant', () => {
     it('shows restaurant info', () => {
       useSelector.mockImplementation((selector) => selector({
         restaurant,
       }));
 
-      const { container } = render(<RestaurantContainer />);
+      const { container } = render(<RestaurantContainer restaurantId={1} />);
 
       expect(container).toHaveTextContent('양천주가');
       expect(container).toHaveTextContent(/서울 강남구/i);
@@ -32,7 +38,7 @@ describe('<RestaurantContainer />', () => {
         restaurant: null,
       }));
 
-      const { container } = render(<RestaurantContainer />);
+      const { container } = render(<RestaurantContainer restaurantId={null} />);
 
       expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
     });

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -19,7 +19,6 @@ describe('<RestaurantContainer />', () => {
 
       const { container } = render(<RestaurantContainer />);
 
-      expect(container).toHaveTextContent('Restaurant1');
       expect(container).toHaveTextContent('양천주가');
       expect(container).toHaveTextContent(/서울 강남구/i);
       expect(container).toHaveTextContent(/탕수육/i);

--- a/src/RestaurantContainer.test.jsx
+++ b/src/RestaurantContainer.test.jsx
@@ -26,17 +26,15 @@ describe('<RestaurantContainer />', () => {
     });
   });
 
-  // context('without restaurant', () => {
-  //   it('shows loading message', () => {
-  //     useSelector.mockImplementation((selector) => selector({
-  //       restaurant: null,
-  //     }));
+  context('without restaurant', () => {
+    it('shows loading message', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurant: null,
+      }));
 
-  //     const { container } = render(<RestaurantContainer />);
+      const { container } = render(<RestaurantContainer />);
 
-  //     expect(dispatch).toBeCalled();
-
-  //     expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
-  //   });
-  // });
+      expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
+    });
+  });
 });

--- a/src/RestaurantDetail.jsx
+++ b/src/RestaurantDetail.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function RestaurantDetail({ restaurant }) {
+  return (
+    <div>
+      <h3>{restaurant.name}</h3>
+      <p>
+        주소:
+        {restaurant.address}
+      </p>
+      <h3>메뉴</h3>
+      <ul>
+        {
+          restaurant.menuItems.map((menu) => (
+            <li key={menu.id}>{menu.name}</li>
+          ))
+        }
+      </ul>
+    </div>
+  );
+}

--- a/src/RestaurantDetail.jsx
+++ b/src/RestaurantDetail.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
 export default function RestaurantDetail({ restaurant }) {
+  if (!restaurant) {
+    return <p>식당 정보를 불러오고 있습니다...</p>;
+  }
+
   return (
     <div>
       <h3>{restaurant.name}</h3>

--- a/src/RestaurantDetail.test.jsx
+++ b/src/RestaurantDetail.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import RestaurantDetail from './RestaurantDetail';
+
+import restaurant from '../fixtures/restaurant';
+
+jest.mock('react-redux');
+
+describe('<RestaurantDetail />', () => {
+  context('with restaurant', () => {
+    it('shows restaurant info', () => {
+      const { container } = render(<RestaurantDetail restaurant={restaurant} />);
+
+      expect(container).toHaveTextContent('양천주가');
+      expect(container).toHaveTextContent(/서울 강남구/i);
+      expect(container).toHaveTextContent(/탕수육/i);
+      expect(container).toHaveTextContent(/팔보채/i);
+    });
+  });
+
+  // context('without restaurant', () => {
+  //   it('shows loading message', () => {
+  //     const { container } = render(<RestaurantDetail restaurant={restaurant} />);
+
+  //     expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
+  //   });
+  // });
+});

--- a/src/RestaurantDetail.test.jsx
+++ b/src/RestaurantDetail.test.jsx
@@ -19,12 +19,4 @@ describe('<RestaurantDetail />', () => {
       expect(container).toHaveTextContent(/팔보채/i);
     });
   });
-
-  // context('without restaurant', () => {
-  //   it('shows loading message', () => {
-  //     const { container } = render(<RestaurantDetail restaurant={restaurant} />);
-
-  //     expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
-  //   });
-  // });
 });

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Restaurant() {
+  return (
+    <div>
+      <h2>Restaurant</h2>
+    </div>
+  );
+}

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -5,6 +5,10 @@ import { useParams } from 'react-router-dom';
 export default function RestaurantPage() {
   const { restaurantId } = useParams();
 
+  useEffect(() => {
+    dispatch(loadRestaurant(restaurantId));
+  }, []);
+
   return (
     <div>
       <h2>

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -17,9 +17,13 @@ export default function RestaurantPage() {
 
   useEffect(() => {
     dispatch(loadRestaurant(restaurantId));
-  });
+  }, []);
 
   const restaurant = useSelector(get('restaurant'));
+
+  if (!restaurant) {
+    return <p>식당 정보를 불러오고 있습니다...</p>;
+  }
 
   return (
     <div>

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -10,8 +10,8 @@ import {
 
 import { get } from './utils';
 
-export default function RestaurantPage() {
-  const { restaurantId } = useParams();
+export default function RestaurantPage({ params }) {
+  const { restaurantId } = params || useParams();
 
   const dispatch = useDispatch();
 

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 
-export default function Restaurant() {
+import { useParams } from 'react-router-dom';
+
+export default function RestaurantPage() {
+  const { restaurantId } = useParams();
+
   return (
     <div>
-      <h2>Restaurant</h2>
+      <h2>
+        Restaurant
+        {restaurantId}
+      </h2>
     </div>
   );
 }

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useParams } from 'react-router-dom';
 
@@ -8,15 +8,18 @@ import {
   loadRestaurant,
 } from './actions';
 
+import { get } from './utils';
+
 export default function RestaurantPage() {
   const { restaurantId } = useParams();
 
-  // TODO : 서버로부터 restaurant 가져오기
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(loadRestaurant(restaurantId));
   });
+
+  const restaurant = useSelector(get('restaurant'));
 
   return (
     <div>
@@ -24,12 +27,18 @@ export default function RestaurantPage() {
         Restaurant
         {restaurantId}
       </h2>
-      <h3>양천주가</h3>
-      <p>주소: 서울시 강남구</p>
+      <h3>{restaurant.name}</h3>
+      <p>
+        주소:
+        {restaurant.address}
+      </p>
       <h3>메뉴</h3>
       <ul>
-        <li>탕수육</li>
-        <li>팔보채</li>
+        {
+          restaurant.menuItems.map((menu) => (
+            <li key={menu.id}>{menu.name}</li>
+          ))
+        }
       </ul>
     </div>
   );

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,23 +1,11 @@
-import React, { useEffect } from 'react';
-
-import { useDispatch } from 'react-redux';
+import React from 'react';
 
 import { useParams } from 'react-router-dom';
-
-import {
-  loadRestaurant,
-} from './actions';
 
 import RestaurantContainer from './RestaurantContainer';
 
 export default function RestaurantPage({ params }) {
   const { restaurantId } = params || useParams();
-
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(loadRestaurant(restaurantId));
-  }, []);
 
   return (
     <div>
@@ -25,7 +13,7 @@ export default function RestaurantPage({ params }) {
         Restaurant
         {restaurantId}
       </h2>
-      <RestaurantContainer />
+      <RestaurantContainer restaurantId={restaurantId} />
     </div>
   );
 }

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -5,16 +5,19 @@ import { useParams } from 'react-router-dom';
 export default function RestaurantPage() {
   const { restaurantId } = useParams();
 
-  useEffect(() => {
-    dispatch(loadRestaurant(restaurantId));
-  }, []);
-
   return (
     <div>
       <h2>
         Restaurant
         {restaurantId}
       </h2>
+      <h3>양천주가</h3>
+      <p>주소: 서울시 강남구</p>
+      <h3>메뉴</h3>
+      <ul>
+        <li>탕수육</li>
+        <li>팔보채</li>
+      </ul>
     </div>
   );
 }

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
 
 import { useParams } from 'react-router-dom';
 
+import {
+  loadRestaurant,
+} from './actions';
+
 export default function RestaurantPage() {
   const { restaurantId } = useParams();
+
+  // TODO : 서버로부터 restaurant 가져오기
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadRestaurant(restaurantId));
+  });
 
   return (
     <div>

--- a/src/RestaurantPage.jsx
+++ b/src/RestaurantPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useParams } from 'react-router-dom';
 
@@ -8,7 +8,7 @@ import {
   loadRestaurant,
 } from './actions';
 
-import { get } from './utils';
+import RestaurantContainer from './RestaurantContainer';
 
 export default function RestaurantPage({ params }) {
   const { restaurantId } = params || useParams();
@@ -19,31 +19,13 @@ export default function RestaurantPage({ params }) {
     dispatch(loadRestaurant(restaurantId));
   }, []);
 
-  const restaurant = useSelector(get('restaurant'));
-
-  if (!restaurant) {
-    return <p>식당 정보를 불러오고 있습니다...</p>;
-  }
-
   return (
     <div>
       <h2>
         Restaurant
         {restaurantId}
       </h2>
-      <h3>{restaurant.name}</h3>
-      <p>
-        주소:
-        {restaurant.address}
-      </p>
-      <h3>메뉴</h3>
-      <ul>
-        {
-          restaurant.menuItems.map((menu) => (
-            <li key={menu.id}>{menu.name}</li>
-          ))
-        }
-      </ul>
+      <RestaurantContainer />
     </div>
   );
 }

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -21,6 +21,10 @@ describe('<RestaurantPage />', () => {
   });
 
   it('shows page name', () => {
+    useSelector.mockImplementation((selector) => selector({
+      restaurant,
+    }));
+
     const { container } = render(<RestaurantPage />);
 
     expect(container).toHaveTextContent('Restaurant');
@@ -37,7 +41,7 @@ describe('<RestaurantPage />', () => {
 
     expect(container).toHaveTextContent('Restaurant1');
     expect(container).toHaveTextContent('양천주가');
-    expect(container).toHaveTextContent(/서울시 강남구/i);
+    expect(container).toHaveTextContent(/서울 강남구/i);
     expect(container).toHaveTextContent(/탕수육/i);
     expect(container).toHaveTextContent(/팔보채/i);
   });

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -2,14 +2,21 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { useDispatch, useSelector } from 'react-redux';
+
 import { useParams } from 'react-router-dom';
 
 import RestaurantPage from './RestaurantPage';
 
+import restaurant from '../fixtures/restaurant';
+
 jest.mock('react-router-dom');
 
 describe('<RestaurantPage />', () => {
+  const dispatch = jest.fn();
+
   beforeEach(() => {
+    useDispatch.mockImplementation(() => dispatch);
     useParams.mockReturnValue({ restaurantId: 1 });
   });
 
@@ -20,7 +27,13 @@ describe('<RestaurantPage />', () => {
   });
 
   it('shows restaurant info', () => {
+    useSelector.mockImplementation((selector) => selector({
+      restaurant,
+    }));
+
     const { container } = render(<RestaurantPage />);
+
+    expect(dispatch).toBeCalled();
 
     expect(container).toHaveTextContent('Restaurant1');
     expect(container).toHaveTextContent('양천주가');

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import RestaurantPage from './RestaurantPage';
+
+test('RestaurantPage', () => {
+  const { container } = render(<RestaurantPage />);
+
+  expect(container).toHaveTextContent('Restaurant');
+});

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -4,20 +4,15 @@ import { render } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useParams } from 'react-router-dom';
-
 import RestaurantPage from './RestaurantPage';
 
 import restaurant from '../fixtures/restaurant';
-
-jest.mock('react-router-dom');
 
 describe('<RestaurantPage />', () => {
   const dispatch = jest.fn();
 
   beforeEach(() => {
     useDispatch.mockImplementation(() => dispatch);
-    useParams.mockReturnValue({ restaurantId: 1 });
   });
 
   it('shows page name', () => {
@@ -25,7 +20,7 @@ describe('<RestaurantPage />', () => {
       restaurant,
     }));
 
-    const { container } = render(<RestaurantPage />);
+    const { container } = render(<RestaurantPage params={{ restaurantId: 1 }} />);
 
     expect(container).toHaveTextContent('Restaurant');
   });
@@ -36,7 +31,7 @@ describe('<RestaurantPage />', () => {
         restaurant,
       }));
 
-      const { container } = render(<RestaurantPage />);
+      const { container } = render(<RestaurantPage params={{ restaurantId: 1 }} />);
 
       expect(dispatch).toBeCalled();
 
@@ -49,12 +44,12 @@ describe('<RestaurantPage />', () => {
   });
 
   context('without restaurant', () => {
-    it('shows restaurant info', () => {
+    it('shows loading message', () => {
       useSelector.mockImplementation((selector) => selector({
         restaurant: null,
       }));
 
-      const { container } = render(<RestaurantPage />);
+      const { container } = render(<RestaurantPage params={{ restaurantId: null }} />);
 
       expect(dispatch).toBeCalled();
 

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -4,8 +4,19 @@ import { render } from '@testing-library/react';
 
 import RestaurantPage from './RestaurantPage';
 
-test('RestaurantPage', () => {
-  const { container } = render(<RestaurantPage />);
+describe('<RestaurantPage />', () => {
+  it('shows header and page name', () => {
+    const { container } = render(<RestaurantPage />);
+    expect(container).toHaveTextContent('헤더');
+    expect(container).toHaveTextContent('Restaurant');
+  });
 
-  expect(container).toHaveTextContent('Restaurant');
+  it('shows restaurant info', () => {
+    const { container } = render(<RestaurantPage />);
+
+    expect(container).toHaveTextContent('양천주가');
+    expect(container).toHaveTextContent('서울시 강남구');
+    expect(container).toHaveTextContent('탕수육');
+    expect(container).toHaveTextContent('팔보채');
+  });
 });

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -2,21 +2,30 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { useParams } from 'react-router-dom';
+
 import RestaurantPage from './RestaurantPage';
 
+jest.mock('react-router-dom');
+
 describe('<RestaurantPage />', () => {
-  it('shows header and page name', () => {
+  beforeEach(() => {
+    useParams.mockReturnValue({ restaurantId: 1 });
+  });
+
+  it('shows page name', () => {
     const { container } = render(<RestaurantPage />);
-    expect(container).toHaveTextContent('헤더');
+
     expect(container).toHaveTextContent('Restaurant');
   });
 
   it('shows restaurant info', () => {
     const { container } = render(<RestaurantPage />);
 
+    expect(container).toHaveTextContent('Restaurant1');
     expect(container).toHaveTextContent('양천주가');
-    expect(container).toHaveTextContent('서울시 강남구');
-    expect(container).toHaveTextContent('탕수육');
-    expect(container).toHaveTextContent('팔보채');
+    expect(container).toHaveTextContent(/서울시 강남구/i);
+    expect(container).toHaveTextContent(/탕수육/i);
+    expect(container).toHaveTextContent(/팔보채/i);
   });
 });

--- a/src/RestaurantPage.test.jsx
+++ b/src/RestaurantPage.test.jsx
@@ -30,19 +30,35 @@ describe('<RestaurantPage />', () => {
     expect(container).toHaveTextContent('Restaurant');
   });
 
-  it('shows restaurant info', () => {
-    useSelector.mockImplementation((selector) => selector({
-      restaurant,
-    }));
+  context('with restaurant', () => {
+    it('shows restaurant info', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurant,
+      }));
 
-    const { container } = render(<RestaurantPage />);
+      const { container } = render(<RestaurantPage />);
 
-    expect(dispatch).toBeCalled();
+      expect(dispatch).toBeCalled();
 
-    expect(container).toHaveTextContent('Restaurant1');
-    expect(container).toHaveTextContent('양천주가');
-    expect(container).toHaveTextContent(/서울 강남구/i);
-    expect(container).toHaveTextContent(/탕수육/i);
-    expect(container).toHaveTextContent(/팔보채/i);
+      expect(container).toHaveTextContent('Restaurant1');
+      expect(container).toHaveTextContent('양천주가');
+      expect(container).toHaveTextContent(/서울 강남구/i);
+      expect(container).toHaveTextContent(/탕수육/i);
+      expect(container).toHaveTextContent(/팔보채/i);
+    });
+  });
+
+  context('without restaurant', () => {
+    it('shows restaurant info', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurant: null,
+      }));
+
+      const { container } = render(<RestaurantPage />);
+
+      expect(dispatch).toBeCalled();
+
+      expect(container).toHaveTextContent('식당 정보를 불러오고 있습니다...');
+    });
   });
 });

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import { useSelector } from 'react-redux';
 
 import { get } from './utils';
@@ -11,7 +13,10 @@ export default function RestaurantsContainer() {
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          {restaurant.name}
+          <Link to={`/restaurant/${restaurant.id}`}>
+            {restaurant.name}
+            {' '}
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -13,7 +13,7 @@ export default function RestaurantsContainer() {
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          <Link to={`/restaurant/${restaurant.id}`}>
+          <Link to={`/restaurants/${restaurant.id}`}>
             {restaurant.name}
             {' '}
           </Link>

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 
 import { useSelector } from 'react-redux';
 
+import { MemoryRouter } from 'react-router-dom';
 import RestaurantsContainer from './RestaurantsContainer';
 
 test('RestaurantsContainer', () => {
@@ -14,7 +15,9 @@ test('RestaurantsContainer', () => {
   }));
 
   const { container } = render((
-    <RestaurantsContainer />
+    <MemoryRouter>
+      <RestaurantsContainer />
+    </MemoryRouter>
   ));
 
   expect(container).toHaveTextContent('마법사주방');

--- a/src/RestaurantsPage.jsx
+++ b/src/RestaurantsPage.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import RegionsContainer from './RegionsContainer';
+import CategoriesContainer from './CategoriesContainer';
+import RestaurantsContainer from './RestaurantsContainer';
+
+import {
+  loadInitialData,
+} from './actions';
+
+export default function RestaurantsPage() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadInitialData());
+  });
+
+  return (
+    <div>
+      <RegionsContainer />
+      <CategoriesContainer />
+      <RestaurantsContainer />
+    </div>
+  );
+}

--- a/src/RestaurantsPage.jsx
+++ b/src/RestaurantsPage.jsx
@@ -19,6 +19,7 @@ export default function RestaurantsPage() {
 
   return (
     <div>
+      <h2>Restaurants</h2>
       <RegionsContainer />
       <CategoriesContainer />
       <RestaurantsContainer />

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -19,7 +19,11 @@ test('RestaurantsPage', () => {
     restaurants: [{ id: 1, name: '마법사주방' }],
   }));
 
-  const { queryByText } = render(<MemoryRouter><RestaurantsPage /></MemoryRouter>);
+  const { queryByText } = render((
+    <MemoryRouter>
+      <RestaurantsPage />
+    </MemoryRouter>
+  ));
 
   expect(dispatch).toBeCalled();
 

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantsPage from './RestaurantsPage';
@@ -17,7 +19,7 @@ test('RestaurantsPage', () => {
     restaurants: [{ id: 1, name: '마법사주방' }],
   }));
 
-  const { queryByText } = render(<RestaurantsPage />);
+  const { queryByText } = render(<MemoryRouter><RestaurantsPage /></MemoryRouter>);
 
   expect(dispatch).toBeCalled();
 

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import RestaurantsPage from './RestaurantsPage';
+
+test('RestaurantsPage', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
+
+  useSelector.mockImplementation((selector) => selector({
+    regions: [{ id: 1, name: '서울' }],
+    categories: [{ id: 1, name: '한식' }],
+    restaurants: [{ id: 1, name: '마법사주방' }],
+  }));
+
+  const { queryByText } = render(<RestaurantsPage />);
+
+  expect(dispatch).toBeCalled();
+
+  expect(queryByText('서울')).not.toBeNull();
+  expect(queryByText('한식')).not.toBeNull();
+});

--- a/src/actions.js
+++ b/src/actions.js
@@ -28,7 +28,7 @@ export function setRestaurants(restaurants) {
 
 export function setRestaurant(restaurant) {
   return {
-    type: 'setRestaurants',
+    type: 'setRestaurant',
     payload: { restaurant },
   };
 }
@@ -76,7 +76,7 @@ export function loadRestaurants() {
   };
 }
 
-export function loadRestaurant(restaurantId) {
+export function loadRestaurant({ restaurantId }) {
   return async (dispatch) => {
     const restaurant = await fetchRestaurant({
       restaurantId,

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,6 +2,7 @@ import {
   fetchRegions,
   fetchCategories,
   fetchRestaurants,
+  fetchRestaurant,
 } from './services/api';
 
 export function setRegions(regions) {
@@ -22,6 +23,13 @@ export function setRestaurants(restaurants) {
   return {
     type: 'setRestaurants',
     payload: { restaurants },
+  };
+}
+
+export function setRestaurant(restaurant) {
+  return {
+    type: 'setRestaurants',
+    payload: { restaurant },
   };
 }
 
@@ -65,5 +73,14 @@ export function loadRestaurants() {
       categoryId: category.id,
     });
     dispatch(setRestaurants(restaurants));
+  };
+}
+
+export function loadRestaurant(restaurantId) {
+  return async (dispatch) => {
+    const restaurant = await fetchRestaurant({
+      restaurantId,
+    });
+    dispatch(setRestaurant(restaurant));
   };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -76,11 +76,9 @@ export function loadRestaurants() {
   };
 }
 
-export function loadRestaurant({ restaurantId }) {
+export function loadRestaurant(id) {
   return async (dispatch) => {
-    const restaurant = await fetchRestaurant({
-      restaurantId,
-    });
+    const restaurant = await fetchRestaurant({ restaurantId: id });
     dispatch(setRestaurant(restaurant));
   };
 }

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -92,7 +92,7 @@ describe('actions', () => {
     });
 
     it('runs setRestaurant', async () => {
-      await store.dispatch(loadRestaurant());
+      await store.dispatch(loadRestaurant({ restaurantId: 1 }));
 
       const actions = store.getActions();
 

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -8,6 +8,8 @@ import {
   setCategories,
   loadRestaurants,
   setRestaurants,
+  loadRestaurant,
+  setRestaurant,
 } from './actions';
 
 const middlewares = [thunk];

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -83,4 +83,18 @@ describe('actions', () => {
       });
     });
   });
+
+  describe('loadRestaurant', () => {
+    beforeEach(() => {
+      store = mockStore({});
+    });
+
+    it('runs setRestaurant', async () => {
+      await store.dispatch(loadRestaurant());
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual(setRestaurant({}));
+    });
+  });
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { BrowserRouter } from 'react-router-dom';
+
 import { Provider } from 'react-redux';
 
 import App from './App';
@@ -10,7 +12,10 @@ import store from './store';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+      ,
     </Provider>
   ),
   document.getElementById('app'),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,6 +6,7 @@ const initialState = {
   restaurants: [],
   selectedRegion: null,
   selectedCategory: null,
+  restaurant: null,
 };
 
 const reducers = {
@@ -29,7 +30,12 @@ const reducers = {
       restaurants,
     };
   },
-
+  setRestaurant(state, { payload: { restaurant } }) {
+    return {
+      ...state,
+      restaurant,
+    };
+  },
   selectRegion(state, { payload: { regionId } }) {
     const { regions } = state;
     return {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -121,7 +121,7 @@ describe('reducer', () => {
 
       const state = reducer(initialState, setRestaurant(restaurant));
 
-      expect(state.restaurant).not.toBeNull();
+      expect(state.restaurant).toEqual(restaurant);
     });
   });
 });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -6,9 +6,10 @@ import {
   setRestaurants,
   selectRegion,
   selectCategory,
+  setRestaurant,
 } from './actions';
 
-import { restaurant } from '../fixtures/restaurant';
+import restaurant from '../fixtures/restaurant';
 
 describe('reducer', () => {
   context('when previous state is undefined', () => {
@@ -18,6 +19,7 @@ describe('reducer', () => {
       restaurants: [],
       selectedRegion: null,
       selectedCategory: null,
+      restaurant: null,
     };
 
     it('returns initialState', () => {
@@ -114,12 +116,12 @@ describe('reducer', () => {
   describe('setRestaurant', () => {
     it('changes restaurant', () => {
       const initialState = {
-        restaurants: {},
+        restaurant: null,
       };
 
       const state = reducer(initialState, setRestaurant(restaurant));
 
-      expect(state.restaurant).toHaveLength(restaurant);
+      expect(state.restaurant).not.toBeNull();
     });
   });
 });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -8,6 +8,8 @@ import {
   selectCategory,
 } from './actions';
 
+import { restaurant } from '../fixtures/restaurant';
+
 describe('reducer', () => {
   context('when previous state is undefined', () => {
     const initialState = {
@@ -106,6 +108,18 @@ describe('reducer', () => {
         id: 1,
         name: '한식',
       });
+    });
+  });
+
+  describe('setRestaurant', () => {
+    it('changes restaurant', () => {
+      const initialState = {
+        restaurants: {},
+      };
+
+      const state = reducer(initialState, setRestaurant(restaurant));
+
+      expect(state.restaurant).toHaveLength(restaurant);
     });
   });
 });

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -9,3 +9,7 @@ export async function fetchCategories() {
 export async function fetchRestaurants() {
   return [];
 }
+
+export async function fetchRestaurant() {
+  return {};
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -19,3 +19,10 @@ export async function fetchRestaurants({ regionName, categoryId }) {
   const data = await response.json();
   return data;
 }
+
+export async function fetchRestaurant({ restaurantId }) {
+  const url = `https://eatgo-customer-api.ahastudio.com/restaurants/${restaurantId}`;
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -2,10 +2,10 @@ import {
   fetchRegions, fetchCategories, fetchRestaurants, fetchRestaurant,
 } from './api';
 
-import REGIONS from '../../fixtures/regions';
-import CATEGORIES from '../../fixtures/categories';
-import RESTAURANTS from '../../fixtures/restaurants';
-import RESTAURANT from '../../fixtures/restaurant';
+import regions from '../../fixtures/regions';
+import categories from '../../fixtures/categories';
+import restaurants from '../../fixtures/restaurants';
+import restaurant from '../../fixtures/restaurant';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -16,54 +16,54 @@ describe('api', () => {
 
   describe('fetchRegions', () => {
     beforeEach(() => {
-      mockFetch(REGIONS);
+      mockFetch(regions);
     });
 
     it('returns regions', async () => {
-      const regions = await fetchRegions();
+      const data = await fetchRegions();
 
-      expect(regions).toEqual(REGIONS);
+      expect(data).toEqual(regions);
     });
   });
 
   describe('fetchCategories', () => {
     beforeEach(() => {
-      mockFetch(CATEGORIES);
+      mockFetch(categories);
     });
 
     it('returns categories', async () => {
-      const categories = await fetchCategories();
+      const data = await fetchCategories();
 
-      expect(categories).toEqual(CATEGORIES);
+      expect(data).toEqual(categories);
     });
   });
 
   describe('fetchRestaurants', () => {
     beforeEach(() => {
-      mockFetch(RESTAURANTS);
+      mockFetch(restaurants);
     });
 
     it('returns restaurants', async () => {
-      const restaurants = await fetchRestaurants({
+      const data = await fetchRestaurants({
         regionName: '서울',
         categoryId: 1,
       });
 
-      expect(restaurants).toEqual(RESTAURANTS);
+      expect(data).toEqual(restaurants);
     });
   });
 
   describe('fetchRestaurant', () => {
     beforeEach(() => {
-      mockFetch(RESTAURANT);
+      mockFetch(restaurant);
     });
 
     it('returns restaurants', async () => {
-      const restaurant = await fetchRestaurant({
+      const data = await fetchRestaurant({
         restaurantId: 1,
       });
 
-      expect(restaurant).toEqual(RESTAURANT);
+      expect(data).toEqual(restaurant);
     });
   });
 });

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,8 +1,11 @@
-import { fetchRegions, fetchCategories, fetchRestaurants } from './api';
+import {
+  fetchRegions, fetchCategories, fetchRestaurants, fetchRestaurant,
+} from './api';
 
 import REGIONS from '../../fixtures/regions';
 import CATEGORIES from '../../fixtures/categories';
 import RESTAURANTS from '../../fixtures/restaurants';
+import RESTAURANT from '../../fixtures/restaurant';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -47,6 +50,20 @@ describe('api', () => {
       });
 
       expect(restaurants).toEqual(RESTAURANTS);
+    });
+  });
+
+  describe('fetchRestaurant', () => {
+    beforeEach(() => {
+      mockFetch(RESTAURANT);
+    });
+
+    it('returns restaurants', async () => {
+      const restaurant = await fetchRestaurant({
+        restaurantId: 1,
+      });
+
+      expect(restaurant).toEqual(RESTAURANT);
     });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,4 +14,9 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+  devServer: {
+    historyApiFallback: {
+      index: 'index.html',
+    },
+  },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,13 @@
 const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: path.resolve(__dirname, 'src/index.jsx'),
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'main.js',
+    publicPath: '/',
+  },
   module: {
     rules: [
       {
@@ -15,8 +21,11 @@ module.exports = {
     extensions: ['.js', '.jsx'],
   },
   devServer: {
-    historyApiFallback: {
-      index: 'index.html',
-    },
+    historyApiFallback: true,
   },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'index.html',
+    }),
+  ],
 };


### PR DESCRIPTION
- 일단 PR 만들었어요~😃

## 진행상황 (Update : a1d297a)
 - [x] URL 별 다른 페이지 보이게 하기
 - [x] AboutPage, Homepage, NotFoundPage 구현
 - [x] RestaurantsPage에서 restaurant 클릭시, 상세 페이지로 이동
 - [x] http://localhost:8080/restaurants/1 로 접속했을 때, 빈 화면 출력 문제 해결
 - [x] useParams mock 제거
 - [x] 레스토랑 상세보기 페이지 관련 컴포넌트 관심사 분리
 

## 회고
 - 컴포넌트별 뿐만 아니라 테스트에서도 관심사 분리 항상 신경쓰기!
 - webpack 설정 공부하기
 - 영어를 두려워하지 말자!!
 - 여러 페이지를 대충 보지 말고, 1페이지를 꼼꼼히 보자!
 - 테스트 이름 좀더 신경쓰기!