### PR TITLE
Restaurant router

### DIFF
--- a/fixtures/restaurant.js
+++ b/fixtures/restaurant.js
@@ -1,0 +1,14 @@
+const restaurant = {
+  id: 1,
+  name: '양천주가',
+  address: '서울 강남구 123456',
+  menuItems: [
+    {
+      id: 1,
+      restaurantId: 1,
+      name: '비빔밥',
+    },
+  ],
+};
+
+export default restaurant;

--- a/fixtures/restaurantInfo.js
+++ b/fixtures/restaurantInfo.js
@@ -1,4 +1,4 @@
-const restaurant = {
+const restaurantInfo = {
   id: 1,
   name: '양천주가',
   address: '서울 강남구 123456',
@@ -11,4 +11,4 @@ const restaurant = {
   ],
 };
 
-export default restaurant;
+export default restaurantInfo;

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>Demo</title>
   </head>
   <body>
     <div id="app"></div>
-    <script src="main.js"></script>
+    <script src="/main.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6397,6 +6397,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -9304,6 +9317,25 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10790,6 +10822,52 @@
         "react-is": "^16.9.0"
       }
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -11170,6 +11248,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12698,6 +12781,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13124,6 +13217,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
+    "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   }

--- a/src/AboutPage.jsx
+++ b/src/AboutPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AboutPage() {
+  return (
+    <div>
+      <h2>About</h2>
+      <p>About 페이지입니다.</p>
+    </div>
+  );
+}

--- a/src/AboutPage.test.jsx
+++ b/src/AboutPage.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import AboutPage from './AboutPage';
+
+describe('AboutPage', () => {
+  it('renders about page', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+
+    ));
+
+    expect(container).toHaveTextContent('About');
+    expect(container).toHaveTextContent('About 페이지입니다.');
+  });
+});

--- a/src/AboutPage.test.jsx
+++ b/src/AboutPage.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import { render } from '@testing-library/react';
 
 import AboutPage from './AboutPage';
@@ -9,10 +7,7 @@ import AboutPage from './AboutPage';
 describe('AboutPage', () => {
   it('renders about page', () => {
     const { container } = render((
-      <MemoryRouter>
-        <AboutPage />
-      </MemoryRouter>
-
+      <AboutPage />
     ));
 
     expect(container).toHaveTextContent('About');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,11 @@ import React, { useEffect } from 'react';
 
 import { useDispatch } from 'react-redux';
 
+import {
+  Switch,
+  Route,
+} from 'react-router-dom';
+
 import Header from './Header';
 
 import RegionsContainer from './RegionsContainer';
@@ -11,6 +16,14 @@ import RestaurantsContainer from './RestaurantsContainer';
 import {
   loadInitialData,
 } from './actions';
+
+function HomePage() {
+  return (
+    <div>
+      <h2>Home</h2>
+    </div>
+  );
+}
 
 export default function App() {
   const dispatch = useDispatch();
@@ -22,6 +35,9 @@ export default function App() {
   return (
     <div>
       <Header />
+      <Switch>
+        <Route exact path="/" component={HomePage} />
+      </Switch>
       <RegionsContainer />
       <CategoriesContainer />
       <RestaurantsContainer />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import {
 import Header from './Header';
 
 import HomePage from './HomePage';
+import AboutPage from './AboutPage';
 
 import RegionsContainer from './RegionsContainer';
 import CategoriesContainer from './CategoriesContainer';
@@ -31,6 +32,7 @@ export default function App() {
       <Header />
       <Switch>
         <Route exact path="/" component={HomePage} />
+        <Route path="/about" component={AboutPage} />
       </Switch>
       <RegionsContainer />
       <CategoriesContainer />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,17 @@ import {
   loadInitialData,
 } from './actions';
 
+function RestaurantsPage() {
+  return (
+    <div>
+      <h2>Restaurants</h2>
+      <RegionsContainer />
+      <CategoriesContainer />
+      <RestaurantsContainer />
+    </div>
+  );
+}
+
 export default function App() {
   const dispatch = useDispatch();
 
@@ -33,10 +44,8 @@ export default function App() {
       <Switch>
         <Route exact path="/" component={HomePage} />
         <Route path="/about" component={AboutPage} />
+        <Route path="/restaurants" component={RestaurantsPage} />
       </Switch>
-      <RegionsContainer />
-      <CategoriesContainer />
-      <RestaurantsContainer />
     </div>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import {
   Switch,
   Route,
+  useParams,
 } from 'react-router-dom';
 
 import Header from './Header';
@@ -16,6 +17,21 @@ import RestaurantsPage from './RestaurantsPage';
 import {
   loadInitialData,
 } from './actions';
+
+function RestaurantInfoPage() {
+  const { restaurantId } = useParams();
+
+  return (
+    <div>
+      <h2>Restaurant Information</h2>
+      <p>
+        Showing the information of
+        {' '}
+        {restaurantId}
+      </p>
+    </div>
+  );
+}
 
 export default function App() {
   const dispatch = useDispatch();
@@ -30,7 +46,8 @@ export default function App() {
       <Switch>
         <Route exact path="/" component={HomePage} />
         <Route path="/about" component={AboutPage} />
-        <Route path="/restaurants" component={RestaurantsPage} />
+        <Route exact path="/restaurants" component={RestaurantsPage} />
+        <Route path="/restaurants/:restaurantId" component={RestaurantInfoPage} />
       </Switch>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,25 +11,11 @@ import Header from './Header';
 
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
-
-import RegionsContainer from './RegionsContainer';
-import CategoriesContainer from './CategoriesContainer';
-import RestaurantsContainer from './RestaurantsContainer';
+import RestaurantsPage from './RestaurantsPage';
 
 import {
   loadInitialData,
 } from './actions';
-
-function RestaurantsPage() {
-  return (
-    <div>
-      <h2>Restaurants</h2>
-      <RegionsContainer />
-      <CategoriesContainer />
-      <RestaurantsContainer />
-    </div>
-  );
-}
 
 export default function App() {
   const dispatch = useDispatch();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,4 @@
-import React, { useEffect } from 'react';
-
-import { useDispatch } from 'react-redux';
+import React from 'react';
 
 import {
   Switch,
@@ -13,24 +11,9 @@ import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
 import RestaurantInfoPage from './RestaurantInfoPage';
-
-import {
-  loadInitialData,
-} from './actions';
-
-function NotFoundPage() {
-  return (
-    <h2>404 Not Found</h2>
-  );
-}
+import NotFoundPage from './NotFoundPage';
 
 export default function App() {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(loadInitialData());
-  });
-
   return (
     <div>
       <Header />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import { useDispatch } from 'react-redux';
 import {
   Switch,
   Route,
-  useParams,
 } from 'react-router-dom';
 
 import Header from './Header';
@@ -13,25 +12,11 @@ import Header from './Header';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
+import RestaurantInfoPage from './RestaurantInfoPage';
 
 import {
   loadInitialData,
 } from './actions';
-
-function RestaurantInfoPage() {
-  const { restaurantId } = useParams();
-
-  return (
-    <div>
-      <h2>Restaurant Information</h2>
-      <p>
-        Showing the information of
-        {' '}
-        {restaurantId}
-      </p>
-    </div>
-  );
-}
 
 export default function App() {
   const dispatch = useDispatch();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import {
 
 import Header from './Header';
 
+import HomePage from './HomePage';
+
 import RegionsContainer from './RegionsContainer';
 import CategoriesContainer from './CategoriesContainer';
 import RestaurantsContainer from './RestaurantsContainer';
@@ -16,14 +18,6 @@ import RestaurantsContainer from './RestaurantsContainer';
 import {
   loadInitialData,
 } from './actions';
-
-function HomePage() {
-  return (
-    <div>
-      <h2>Home</h2>
-    </div>
-  );
-}
 
 export default function App() {
   const dispatch = useDispatch();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,8 +20,8 @@ export default function App() {
       <Switch>
         <Route exact path="/" component={HomePage} />
         <Route path="/about" component={AboutPage} />
-        <Route exact path="/restaurants" component={RestaurantsPage} />
         <Route path="/restaurants/:restaurantId" component={RestaurantInfoPage} />
+        <Route exact path="/restaurants" component={RestaurantsPage} />
         <Route component={NotFoundPage} />
       </Switch>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,12 @@ import {
   loadInitialData,
 } from './actions';
 
+function NotFoundPage() {
+  return (
+    <h2>404 Not Found</h2>
+  );
+}
+
 export default function App() {
   const dispatch = useDispatch();
 
@@ -33,6 +39,7 @@ export default function App() {
         <Route path="/about" component={AboutPage} />
         <Route exact path="/restaurants" component={RestaurantsPage} />
         <Route path="/restaurants/:restaurantId" component={RestaurantInfoPage} />
+        <Route component={NotFoundPage} />
       </Switch>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 
 import { useDispatch } from 'react-redux';
 
+import Header from './Header';
+
 import RegionsContainer from './RegionsContainer';
 import CategoriesContainer from './CategoriesContainer';
 import RestaurantsContainer from './RestaurantsContainer';
@@ -9,12 +11,6 @@ import RestaurantsContainer from './RestaurantsContainer';
 import {
   loadInitialData,
 } from './actions';
-
-function Header() {
-  return (
-    <h1>헤더</h1>
-  );
-}
 
 export default function App() {
   const dispatch = useDispatch();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,10 +10,11 @@ import {
   loadInitialData,
 } from './actions';
 
-// 0. 지역, 분류 목록을 얻기
-// 1. 지역 선택 - Regions <- API (0)
-// 2. 분류 선택 - Categories - 한식, 중식, 일식, ... <- API (0)
-// 3. 식당 목록 - Restaurants <- API (with region, category) -> 1, 2 모두 완료된 경우
+function Header() {
+  return (
+    <h1>헤더</h1>
+  );
+}
 
 export default function App() {
   const dispatch = useDispatch();
@@ -24,6 +25,7 @@ export default function App() {
 
   return (
     <div>
+      <Header />
       <RegionsContainer />
       <CategoriesContainer />
       <RestaurantsContainer />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -22,7 +22,7 @@ describe('App', () => {
       regions,
       categories,
       restaurants,
-      selectedRestaurantInfo: {
+      restaurantInfo: {
         menuItems: [],
       },
     }));

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -57,5 +57,14 @@ describe('App', () => {
 
       expect(container).toHaveTextContent('About');
     });
+
+    it('goes to restaurants page when "restaurants" is clicked', () => {
+      const { container, getByText } = renderApp({ path: '/' });
+
+      fireEvent.click(getByText('Restaurants'));
+
+      expect(container).toHaveTextContent('서울');
+      expect(container).toHaveTextContent('한식');
+    });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -63,8 +63,7 @@ describe('App', () => {
 
       fireEvent.click(getByText('Restaurants'));
 
-      expect(container).toHaveTextContent('서울');
-      expect(container).toHaveTextContent('한식');
+      expect(container).toHaveTextContent('Restaurants');
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -85,8 +85,10 @@ describe('App', () => {
   });
 
   context('with unexisted path', () => {
-    const { container } = renderApp({ path: '/xxx' });
+    it('goes to not found page', () => {
+      const { container } = renderApp({ path: '/xxx' });
 
-    expect(container).toHaveTextContent('Not Found');
+      expect(container).toHaveTextContent('404 Not Found');
+    });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -73,11 +73,9 @@ describe('App', () => {
 
   context('with path /restaurants', () => {
     it('goes to restaurant detail page when specific restaurant is clicked', () => {
-      const { container, getByText, debug } = renderApp({ path: '/restaurants' });
+      const { container, getByText } = renderApp({ path: '/restaurants' });
 
       fireEvent.click(getByText('김밥제국'));
-
-      debug();
 
       expect(container).toHaveTextContent('Restaurant Information');
     });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -6,29 +6,24 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import App from './App';
 
-test('App', () => {
-  const dispatch = jest.fn();
+describe('App', () => {
+  beforeEach(() => {
+    const dispatch = jest.fn();
 
-  useDispatch.mockImplementation(() => dispatch);
+    useDispatch.mockImplementation(() => dispatch);
 
-  useSelector.mockImplementation((selector) => selector({
-    regions: [
-      { id: 1, name: '서울' },
-    ],
-    categories: [
-      { id: 1, name: '한식' },
-    ],
-    restaurants: [
-      { id: 1, name: '마법사주방' },
-    ],
-  }));
+    useSelector.mockImplementation((selector) => selector({
+      regions: [],
+      categories: [],
+      restaurants: [],
+    }));
+  });
 
-  const { queryByText } = render((
-    <App />
-  ));
+  it('renders headers', () => {
+    const { container } = render((
+      <App />
+    ));
 
-  expect(dispatch).toBeCalled();
-
-  expect(queryByText('서울')).not.toBeNull();
-  expect(queryByText('한식')).not.toBeNull();
+    expect(container).toHaveTextContent('헤더');
+  });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -19,11 +19,21 @@ describe('App', () => {
     }));
   });
 
-  it('renders headers', () => {
+  it('renders header', () => {
     const { container } = render((
       <App />
     ));
 
     expect(container).toHaveTextContent('헤더');
+  });
+
+  it('goes to home page when header is clicked', () => {
+    const { container, getByText } = render((
+      <App />
+    ));
+
+    fireEvent.click(getByText('헤더'));
+
+    expect(container).toHaveTextContent('Home');
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -74,6 +74,14 @@ describe('App', () => {
     });
   });
 
+  context('with path /restaurants/:restaurantId', () => {
+    it('goes to restaurant information page', () => {
+      const { container } = renderApp({ path: '/restaurants/1' });
+
+      expect(container).toHaveTextContent('Restaurant Information');
+    });
+  });
+
   context('with path /restaurants', () => {
     it('goes to restaurant detail page when specific restaurant is clicked', () => {
       const { container, getByText } = renderApp({ path: '/restaurants' });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -29,25 +29,33 @@ describe('App', () => {
     ));
   }
 
-  it('renders header', () => {
-    const { container } = renderApp({ path: '/' });
-
-    expect(container).toHaveTextContent('헤더');
-  });
-
-  it('goes to home page when header is clicked', () => {
-    const { container, getByText } = renderApp({ path: '/' });
-
-    fireEvent.click(getByText('헤더'));
-
-    expect(container).toHaveTextContent('Home');
-  });
-
   context('with path /', () => {
+    it('renders header', () => {
+      const { container } = renderApp({ path: '/' });
+
+      expect(container).toHaveTextContent('헤더');
+    });
+
     it('renders home page', () => {
       const { container } = renderApp({ path: '/' });
 
       expect(container).toHaveTextContent('Home');
+    });
+
+    it('goes to home page when header is clicked', () => {
+      const { container, getByText } = renderApp({ path: '/' });
+
+      fireEvent.click(getByText('헤더'));
+
+      expect(container).toHaveTextContent('Home');
+    });
+
+    it('goes to about page when "about" is clicked', () => {
+      const { container, getByText } = renderApp({ path: '/' });
+
+      fireEvent.click(getByText('About'));
+
+      expect(container).toHaveTextContent('About');
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -83,4 +83,10 @@ describe('App', () => {
       expect(container).toHaveTextContent('Restaurant Information');
     });
   });
+
+  context('with unexisted path', () => {
+    const { container } = renderApp({ path: '/xxx' });
+
+    expect(container).toHaveTextContent('Not Found');
+  });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -21,22 +21,22 @@ describe('App', () => {
     }));
   });
 
-  it('renders header', () => {
-    const { container } = render((
-      <MemoryRouter>
+  function renderApp({ path }) {
+    return render((
+      <MemoryRouter initialEntries={[path]}>
         <App />
       </MemoryRouter>
     ));
+  }
+
+  it('renders header', () => {
+    const { container } = renderApp({ path: '/' });
 
     expect(container).toHaveTextContent('헤더');
   });
 
   it('goes to home page when header is clicked', () => {
-    const { container, getByText } = render((
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>
-    ));
+    const { container, getByText } = renderApp({ path: '/' });
 
     fireEvent.click(getByText('헤더'));
 
@@ -45,15 +45,9 @@ describe('App', () => {
 
   context('with path /', () => {
     it('renders home page', () => {
-      const { container } = render((
-        <MemoryRouter initialEntries={['/']}>
-          <App />
-        </MemoryRouter>
-      ));
+      const { container } = renderApp({ path: '/' });
 
       expect(container).toHaveTextContent('Home');
-      expect(container).toHaveTextContent('About');
-      expect(container).toHaveTextContent('Restaurants');
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -42,4 +42,18 @@ describe('App', () => {
 
     expect(container).toHaveTextContent('Home');
   });
+
+  context('with path /', () => {
+    it('renders home page', () => {
+      const { container } = render((
+        <MemoryRouter initialEntries={['/']}>
+          <App />
+        </MemoryRouter>
+      ));
+
+      expect(container).toHaveTextContent('Home');
+      expect(container).toHaveTextContent('About');
+      expect(container).toHaveTextContent('Restaurants');
+    });
+  });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import { render, fireEvent } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
@@ -21,7 +23,9 @@ describe('App', () => {
 
   it('renders header', () => {
     const { container } = render((
-      <App />
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
     ));
 
     expect(container).toHaveTextContent('헤더');
@@ -29,7 +33,9 @@ describe('App', () => {
 
   it('goes to home page when header is clicked', () => {
     const { container, getByText } = render((
-      <App />
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
     ));
 
     fireEvent.click(getByText('헤더'));

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -8,6 +8,10 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import App from './App';
 
+import regions from '../fixtures/regions';
+import categories from '../fixtures/categories';
+import restaurants from '../fixtures/restaurants';
+
 describe('App', () => {
   beforeEach(() => {
     const dispatch = jest.fn();
@@ -15,9 +19,9 @@ describe('App', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      regions: [],
-      categories: [],
-      restaurants: [],
+      regions,
+      categories,
+      restaurants,
     }));
   });
 
@@ -64,6 +68,18 @@ describe('App', () => {
       fireEvent.click(getByText('Restaurants'));
 
       expect(container).toHaveTextContent('Restaurants');
+    });
+  });
+
+  context('with path /restaurants', () => {
+    it('goes to restaurant detail page when specific restaurant is clicked', () => {
+      const { container, getByText, debug } = renderApp({ path: '/restaurants' });
+
+      fireEvent.click(getByText('김밥제국'));
+
+      debug();
+
+      expect(container).toHaveTextContent('Restaurant Information');
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -22,6 +22,9 @@ describe('App', () => {
       regions,
       categories,
       restaurants,
+      selectedRestaurantInfo: {
+        menuItems: [],
+      },
     }));
   });
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Header() {
+  return (
+    <h1>헤더</h1>
+  );
+}

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 export default function Header() {
   return (
-    <h1>헤더</h1>
+    <h1><Link to="/">헤더</Link></h1>
   );
 }

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import { render } from '@testing-library/react';
 
 import Header from './Header';
@@ -7,7 +9,10 @@ import Header from './Header';
 describe('Header', () => {
   it('renders header', () => {
     const { container } = render((
-      <Header />
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+
     ));
 
     expect(container).toHaveTextContent('헤더');

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import Header from './Header';
+
+describe('Header', () => {
+  it('renders header', () => {
+    const { container } = render((
+      <Header />
+    ));
+
+    expect(container).toHaveTextContent('헤더');
+  });
+});

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h2>Home</h2>
+    </div>
+  );
+}

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 export default function HomePage() {
   return (
     <div>
       <h2>Home</h2>
+      <ul>
+        <li><Link to="/about">About</Link></li>
+        <li><Link to="/restaurants">Restaurants</Link></li>
+      </ul>
     </div>
   );
 }

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import HomePage from './HomePage';
+
+describe('HomePage', () => {
+  it('renders home page', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+
+    ));
+
+    expect(container).toHaveTextContent('Home');
+    expect(container).toHaveTextContent('About');
+    expect(container).toHaveTextContent('Restaurants');
+  });
+});

--- a/src/NotFoundPage.jsx
+++ b/src/NotFoundPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function NotFoundPage() {
+  return (
+    <h2>404 Not Found</h2>
+  );
+}

--- a/src/NotFoundPage.test.jsx
+++ b/src/NotFoundPage.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { MemoryRouter } from 'react-router-dom';
-
 import { render } from '@testing-library/react';
 
 import NotFoundPage from './NotFoundPage';
@@ -9,10 +7,7 @@ import NotFoundPage from './NotFoundPage';
 describe('NotFoundPage', () => {
   it('renders not found page', () => {
     const { container } = render((
-      <MemoryRouter>
-        <NotFoundPage />
-      </MemoryRouter>
-
+      <NotFoundPage />
     ));
 
     expect(container).toHaveTextContent('404 Not Found');

--- a/src/NotFoundPage.test.jsx
+++ b/src/NotFoundPage.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import NotFoundPage from './NotFoundPage';
+
+describe('NotFoundPage', () => {
+  it('renders not found page', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+
+    ));
+
+    expect(container).toHaveTextContent('404 Not Found');
+  });
+});

--- a/src/RestaurantInfoContainer.jsx
+++ b/src/RestaurantInfoContainer.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { get } from './utils';
 
 export default function RestaurantInfoContainer() {
-  const { name, address, menuItems } = useSelector(get('selectedRestaurantInfo'));
+  const { name, address, menuItems } = useSelector(get('restaurantInfo'));
 
   return (
     <div>

--- a/src/RestaurantInfoContainer.jsx
+++ b/src/RestaurantInfoContainer.jsx
@@ -5,7 +5,15 @@ import { useSelector } from 'react-redux';
 import { get } from './utils';
 
 export default function RestaurantInfoContainer() {
-  const { name, address, menuItems } = useSelector(get('restaurantInfo'));
+  const restaurantInfo = useSelector(get('restaurantInfo'));
+
+  if (!restaurantInfo) {
+    return (
+      <p>데이터가 없습니다.</p>
+    );
+  }
+
+  const { name, address, menuItems } = restaurantInfo;
 
   return (
     <div>

--- a/src/RestaurantInfoContainer.jsx
+++ b/src/RestaurantInfoContainer.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import {
+  useParams,
+} from 'react-router-dom';
+
+export default function RestaurantInfoContainer() {
+  const { restaurantId } = useParams();
+
+  return (
+    <div>
+      <h2>Restaurant Information</h2>
+      <p>
+        Restaurant id:
+        {' '}
+        {restaurantId}
+      </p>
+      {/* <h3>{restaurant.name}</h3> */}
+      <p>
+        주소:
+        {' '}
+        {/* {restaurant.address} */}
+      </p>
+      <h4>메뉴</h4>
+      {/* <ul>
+        {restaurant.menuItems.map((item) => (
+          <li key={item.id}>
+            {item.name}
+          </li>
+        ))}
+      </ul> */}
+    </div>
+  );
+}

--- a/src/RestaurantInfoContainer.jsx
+++ b/src/RestaurantInfoContainer.jsx
@@ -1,34 +1,29 @@
 import React from 'react';
 
-import {
-  useParams,
-} from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import { get } from './utils';
 
 export default function RestaurantInfoContainer() {
-  const { restaurantId } = useParams();
+  const { name, address, menuItems } = useSelector(get('selectedRestaurantInfo'));
 
   return (
     <div>
       <h2>Restaurant Information</h2>
-      <p>
-        Restaurant id:
-        {' '}
-        {restaurantId}
-      </p>
-      {/* <h3>{restaurant.name}</h3> */}
+      <h3>{name}</h3>
       <p>
         주소:
         {' '}
-        {/* {restaurant.address} */}
+        {address}
       </p>
       <h4>메뉴</h4>
-      {/* <ul>
-        {restaurant.menuItems.map((item) => (
+      <ul>
+        {menuItems.map((item) => (
           <li key={item.id}>
             {item.name}
           </li>
         ))}
-      </ul> */}
+      </ul>
     </div>
   );
 }

--- a/src/RestaurantInfoContainer.jsx
+++ b/src/RestaurantInfoContainer.jsx
@@ -26,9 +26,9 @@ export default function RestaurantInfoContainer() {
       </p>
       <h4>메뉴</h4>
       <ul>
-        {menuItems.map((item) => (
-          <li key={item.id}>
-            {item.name}
+        {menuItems.map(({ id, name: menuName }) => (
+          <li key={id}>
+            {menuName}
           </li>
         ))}
       </ul>

--- a/src/RestaurantInfoContainer.test.jsx
+++ b/src/RestaurantInfoContainer.test.jsx
@@ -9,28 +9,50 @@ import { useSelector } from 'react-redux';
 import RestaurantInfoContainer from './RestaurantInfoContainer';
 
 describe('RestaurantInfoContainer', () => {
-  useSelector.mockImplementation((selector) => selector({
-    restaurantInfo: {
-      id: 1,
-      name: '양천주가',
-      address: '서울 강남구 123456',
-      menuItems: [
-        {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  context('with restaurantInfo', () => {
+    it('renders restaurant information', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo: {
           id: 1,
-          restaurantId: 1,
-          name: '비빔밥',
+          name: '양천주가',
+          address: '서울 강남구 123456',
+          menuItems: [
+            {
+              id: 1,
+              restaurantId: 1,
+              name: '비빔밥',
+            },
+          ],
         },
-      ],
-    },
-  }));
+      }));
 
-  it('renders restaurant information', () => {
-    const { container } = render((
-      <MemoryRouter>
-        <RestaurantInfoContainer />
-      </MemoryRouter>
-    ));
+      const { container } = render((
+        <MemoryRouter>
+          <RestaurantInfoContainer />
+        </MemoryRouter>
+      ));
 
-    expect(container).toHaveTextContent('양천주가');
+      expect(container).toHaveTextContent('양천주가');
+    });
+  });
+
+  context('without restaurantInfo', () => {
+    it('renders "no data" message', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo: null,
+      }));
+
+      const { container } = render((
+        <MemoryRouter>
+          <RestaurantInfoContainer />
+        </MemoryRouter>
+      ));
+
+      expect(container).toHaveTextContent('데이터가 없습니다.');
+    });
   });
 });

--- a/src/RestaurantInfoContainer.test.jsx
+++ b/src/RestaurantInfoContainer.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import RestaurantInfoContainer from './RestaurantInfoContainer';
+
+test('RestaurantInfoContainer', () => {
+  useSelector.mockImplementation((selector) => selector({
+    selectedRestaurantInfo: {
+      id: 1,
+      name: '양천주가',
+      address: '서울 강남구 123456',
+      menuItems: [
+        {
+          id: 1,
+          restaurantId: 1,
+          name: '비빔밥',
+        },
+      ],
+    },
+  }));
+
+  const { container } = render((
+    <MemoryRouter>
+      <RestaurantInfoContainer />
+    </MemoryRouter>
+  ));
+
+  expect(container).toHaveTextContent('양천주가');
+});

--- a/src/RestaurantInfoContainer.test.jsx
+++ b/src/RestaurantInfoContainer.test.jsx
@@ -10,7 +10,7 @@ import RestaurantInfoContainer from './RestaurantInfoContainer';
 
 describe('RestaurantInfoContainer', () => {
   useSelector.mockImplementation((selector) => selector({
-    selectedRestaurantInfo: {
+    restaurantInfo: {
       id: 1,
       name: '양천주가',
       address: '서울 강남구 123456',

--- a/src/RestaurantInfoContainer.test.jsx
+++ b/src/RestaurantInfoContainer.test.jsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 
 import RestaurantInfoContainer from './RestaurantInfoContainer';
 
-test('RestaurantInfoContainer', () => {
+describe('RestaurantInfoContainer', () => {
   useSelector.mockImplementation((selector) => selector({
     selectedRestaurantInfo: {
       id: 1,
@@ -24,11 +24,13 @@ test('RestaurantInfoContainer', () => {
     },
   }));
 
-  const { container } = render((
-    <MemoryRouter>
-      <RestaurantInfoContainer />
-    </MemoryRouter>
-  ));
+  it('renders restaurant information', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <RestaurantInfoContainer />
+      </MemoryRouter>
+    ));
 
-  expect(container).toHaveTextContent('양천주가');
+    expect(container).toHaveTextContent('양천주가');
+  });
 });

--- a/src/RestaurantInfoPage.jsx
+++ b/src/RestaurantInfoPage.jsx
@@ -1,8 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import { useParams } from 'react-router-dom';
 
 import RestaurantInfoContainer from './RestaurantInfoContainer';
 
+import {
+  loadRestaurantInfo,
+  selectRestaurant,
+} from './actions';
+
 export default function RestaurantInfoPage() {
+  const dispatch = useDispatch();
+
+  const restaurantId = useParams();
+
+  useEffect(() => {
+    dispatch(selectRestaurant(restaurantId));
+    dispatch(loadRestaurantInfo());
+  });
+
   return (
     <RestaurantInfoContainer />
   );

--- a/src/RestaurantInfoPage.jsx
+++ b/src/RestaurantInfoPage.jsx
@@ -8,18 +8,16 @@ import RestaurantInfoContainer from './RestaurantInfoContainer';
 
 import {
   loadRestaurantInfo,
-  selectRestaurant,
 } from './actions';
 
 export default function RestaurantInfoPage() {
   const dispatch = useDispatch();
 
-  const restaurantId = useParams();
+  const { restaurantId } = useParams();
 
   useEffect(() => {
-    dispatch(selectRestaurant(restaurantId));
-    dispatch(loadRestaurantInfo());
-  });
+    dispatch(loadRestaurantInfo(restaurantId));
+  }, []);
 
   return (
     <RestaurantInfoContainer />

--- a/src/RestaurantInfoPage.jsx
+++ b/src/RestaurantInfoPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import RestaurantInfoContainer from './RestaurantInfoContainer';
+
+export default function RestaurantInfoPage() {
+  return (
+    <RestaurantInfoContainer />
+  );
+}

--- a/src/RestaurantInfoPage.test.jsx
+++ b/src/RestaurantInfoPage.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@testing-library/react';
+
+import RestaurantInfoPage from './RestaurantInfoPage';
+
+describe('RestaurantInfoPage', () => {
+  it('renders restaurant information page', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <RestaurantInfoPage />
+      </MemoryRouter>
+
+    ));
+
+    expect(container).toHaveTextContent('Restaurant Information');
+  });
+});

--- a/src/RestaurantInfoPage.test.jsx
+++ b/src/RestaurantInfoPage.test.jsx
@@ -4,9 +4,28 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
+import { useSelector } from 'react-redux';
+
 import RestaurantInfoPage from './RestaurantInfoPage';
 
 describe('RestaurantInfoPage', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      selectedRestaurantInfo: {
+        id: 1,
+        name: '양천주가',
+        address: '서울 강남구 123456',
+        menuItems: [
+          {
+            id: 1,
+            restaurantId: 1,
+            name: '비빔밥',
+          },
+        ],
+      },
+    }));
+  });
+
   it('renders restaurant information page', () => {
     const { container } = render((
       <MemoryRouter>

--- a/src/RestaurantInfoPage.test.jsx
+++ b/src/RestaurantInfoPage.test.jsx
@@ -4,12 +4,18 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantInfoPage from './RestaurantInfoPage';
 
 describe('RestaurantInfoPage', () => {
+  const dispatch = jest.fn();
+
   beforeEach(() => {
+    jest.clearAllMocks();
+
+    useDispatch.mockImplementation(() => dispatch);
+
     useSelector.mockImplementation((selector) => selector({
       restaurantInfo: {
         id: 1,

--- a/src/RestaurantInfoPage.test.jsx
+++ b/src/RestaurantInfoPage.test.jsx
@@ -11,7 +11,7 @@ import RestaurantInfoPage from './RestaurantInfoPage';
 describe('RestaurantInfoPage', () => {
   beforeEach(() => {
     useSelector.mockImplementation((selector) => selector({
-      selectedRestaurantInfo: {
+      restaurantInfo: {
         id: 1,
         name: '양천주가',
         address: '서울 강남구 123456',

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { get } from './utils';
 
 import {
-  setRestaurantInfo,
+  selectRestaurant,
   loadRestaurantInfo,
 } from './actions';
 
@@ -16,8 +16,8 @@ export default function RestaurantsContainer() {
 
   const restaurants = useSelector(get('restaurants'));
 
-  function handleClick({ restaurant }) {
-    dispatch(setRestaurantInfo({ restaurant }));
+  function handleClick(restaurantId) {
+    dispatch(selectRestaurant(restaurantId));
     dispatch(loadRestaurantInfo());
   }
 
@@ -27,7 +27,7 @@ export default function RestaurantsContainer() {
         <li key={restaurant.id}>
           <Link
             to={`/restaurants/${restaurant.id}`}
-            onClick={() => handleClick({ restaurant })}
+            onClick={() => handleClick(restaurant.id)}
           >
             {restaurant.name}
           </Link>

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import { useSelector } from 'react-redux';
 
 import { get } from './utils';
@@ -11,7 +13,7 @@ export default function RestaurantsContainer() {
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          {restaurant.name}
+          <Link to={`/restaurants/${restaurant.id}`}>{restaurant.name}</Link>
         </li>
       ))}
     </ul>

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -13,7 +13,9 @@ export default function RestaurantsContainer() {
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          <Link to={`/restaurants/${restaurant.id}`}>{restaurant.name}</Link>
+          <Link to={`/restaurants/${restaurant.id}`}>
+            {restaurant.name}
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -2,33 +2,18 @@ import React from 'react';
 
 import { Link } from 'react-router-dom';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { get } from './utils';
 
-import {
-  selectRestaurant,
-  loadRestaurantInfo,
-} from './actions';
-
 export default function RestaurantsContainer() {
-  const dispatch = useDispatch();
-
   const restaurants = useSelector(get('restaurants'));
-
-  function handleClick(restaurantId) {
-    dispatch(selectRestaurant(restaurantId));
-    dispatch(loadRestaurantInfo());
-  }
 
   return (
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          <Link
-            to={`/restaurants/${restaurant.id}`}
-            onClick={() => handleClick(restaurant.id)}
-          >
+          <Link to={`/restaurants/${restaurant.id}`}>
             {restaurant.name}
           </Link>
         </li>

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -2,18 +2,33 @@ import React from 'react';
 
 import { Link } from 'react-router-dom';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { get } from './utils';
 
+import {
+  setRestaurantInfo,
+  loadRestaurantInfo,
+} from './actions';
+
 export default function RestaurantsContainer() {
+  const dispatch = useDispatch();
+
   const restaurants = useSelector(get('restaurants'));
+
+  function handleClick({ restaurant }) {
+    dispatch(setRestaurantInfo({ restaurant }));
+    dispatch(loadRestaurantInfo());
+  }
 
   return (
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          <Link to={`/restaurants/${restaurant.id}`}>
+          <Link
+            to={`/restaurants/${restaurant.id}`}
+            onClick={() => handleClick({ restaurant })}
+          >
             {restaurant.name}
           </Link>
         </li>

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -2,14 +2,18 @@ import React from 'react';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantsContainer from './RestaurantsContainer';
 
 describe('RestaurantsContainer', () => {
+  const dispatch = jest.fn;
+
   beforeEach(() => {
+    useDispatch.mockImplementation(() => dispatch);
+
     useSelector.mockImplementation((selector) => selector({
       restaurants: [
         { id: 1, name: '마법사주방' },
@@ -25,5 +29,17 @@ describe('RestaurantsContainer', () => {
     ));
 
     expect(container).toHaveTextContent('마법사주방');
+  });
+
+  it('loads clicked restaurant information', () => {
+    const { getByText } = render((
+      <MemoryRouter>
+        <RestaurantsContainer />
+      </MemoryRouter>
+    ));
+
+    fireEvent.click(getByText('마법사주방'));
+
+    expect(dispatch).toBeCalled();
   });
 });

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import { render } from '@testing-library/react';
 
 import { useSelector } from 'react-redux';
@@ -14,7 +16,9 @@ test('RestaurantsContainer', () => {
   }));
 
   const { container } = render((
-    <RestaurantsContainer />
+    <MemoryRouter>
+      <RestaurantsContainer />
+    </MemoryRouter>
   ));
 
   expect(container).toHaveTextContent('마법사주방');

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -9,9 +9,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import RestaurantsContainer from './RestaurantsContainer';
 
 describe('RestaurantsContainer', () => {
-  const dispatch = jest.fn;
+  const dispatch = jest.fn();
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
@@ -40,6 +42,6 @@ describe('RestaurantsContainer', () => {
 
     fireEvent.click(getByText('마법사주방'));
 
-    expect(dispatch).toBeCalled();
+    expect(dispatch).toBeCalledTimes(2);
   });
 });

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -8,18 +8,22 @@ import { useSelector } from 'react-redux';
 
 import RestaurantsContainer from './RestaurantsContainer';
 
-test('RestaurantsContainer', () => {
-  useSelector.mockImplementation((selector) => selector({
-    restaurants: [
-      { id: 1, name: '마법사주방' },
-    ],
-  }));
+describe('RestaurantsContainer', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      restaurants: [
+        { id: 1, name: '마법사주방' },
+      ],
+    }));
+  });
 
-  const { container } = render((
-    <MemoryRouter>
-      <RestaurantsContainer />
-    </MemoryRouter>
-  ));
+  it('renders restaurants', () => {
+    const { container } = render((
+      <MemoryRouter>
+        <RestaurantsContainer />
+      </MemoryRouter>
+    ));
 
-  expect(container).toHaveTextContent('마법사주방');
+    expect(container).toHaveTextContent('마법사주방');
+  });
 });

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -31,17 +31,5 @@ describe('RestaurantsContainer', () => {
     ));
 
     expect(container).toHaveTextContent('마법사주방');
-  });
-
-  it('loads clicked restaurant information', () => {
-    const { getByText } = render((
-      <MemoryRouter>
-        <RestaurantsContainer />
-      </MemoryRouter>
-    ));
-
-    fireEvent.click(getByText('마법사주방'));
-
-    expect(dispatch).toBeCalledTimes(2);
   });
 });

--- a/src/RestaurantsPage.jsx
+++ b/src/RestaurantsPage.jsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import {
+  loadInitialData,
+} from './actions';
 
 import RegionsContainer from './RegionsContainer';
 import CategoriesContainer from './CategoriesContainer';
 import RestaurantsContainer from './RestaurantsContainer';
 
 export default function RestaurantsPage() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadInitialData());
+  });
+
   return (
     <div>
       <h2>Restaurants</h2>

--- a/src/RestaurantsPage.jsx
+++ b/src/RestaurantsPage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import RegionsContainer from './RegionsContainer';
+import CategoriesContainer from './CategoriesContainer';
+import RestaurantsContainer from './RestaurantsContainer';
+
+export default function RestaurantsPage() {
+  return (
+    <div>
+      <h2>Restaurants</h2>
+      <RegionsContainer />
+      <CategoriesContainer />
+      <RestaurantsContainer />
+    </div>
+  );
+}

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import RestaurantsPage from './RestaurantsPage';
+
+import regions from '../fixtures/regions';
+import categories from '../fixtures/categories';
+import restaurants from '../fixtures/restaurants';
+
+describe('RestaurantsPage', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      regions,
+      categories,
+      restaurants,
+    }));
+  });
+
+  it('renders restaurants page', () => {
+    const { container, getByText } = render((
+      <MemoryRouter>
+        <RestaurantsPage />
+      </MemoryRouter>
+    ));
+
+    expect(container).toHaveTextContent('Restaurants');
+    expect(getByText('서울')).not.toBeNull();
+    expect(getByText('한식')).not.toBeNull();
+  });
+
+  it('goes to restaurant detail page', () => {
+    const { container, getByText } = render((
+      <MemoryRouter>
+        <RestaurantsPage />
+      </MemoryRouter>
+    ));
+
+    fireEvent.click(getByText('김밥제국'));
+
+    expect(container).toHaveTextContent('Restaurant Information');
+  });
+});

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { render } from '@testing-library/react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import RestaurantsPage from './RestaurantsPage';
 
@@ -13,7 +13,11 @@ import categories from '../fixtures/categories';
 import restaurants from '../fixtures/restaurants';
 
 describe('RestaurantsPage', () => {
+  const dispatch = jest.fn();
+
   beforeEach(() => {
+    useDispatch.mockImplementation(() => dispatch);
+
     useSelector.mockImplementation((selector) => selector({
       regions,
       categories,

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { useSelector } from 'react-redux';
 
@@ -31,17 +31,5 @@ describe('RestaurantsPage', () => {
     expect(container).toHaveTextContent('Restaurants');
     expect(getByText('서울')).not.toBeNull();
     expect(getByText('한식')).not.toBeNull();
-  });
-
-  it('goes to restaurant detail page', () => {
-    const { container, getByText } = render((
-      <MemoryRouter>
-        <RestaurantsPage />
-      </MemoryRouter>
-    ));
-
-    fireEvent.click(getByText('김밥제국'));
-
-    expect(container).toHaveTextContent('Restaurant Information');
   });
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -26,10 +26,10 @@ export function setRestaurants(restaurants) {
   };
 }
 
-export function setRestaurantInfo(restaurant) {
+export function setRestaurantInfo(restaurantInfo) {
   return {
     type: 'setRestaurantInfo',
-    payload: { restaurant },
+    payload: { restaurantInfo },
   };
 }
 
@@ -44,6 +44,13 @@ export function selectCategory(categoryId) {
   return {
     type: 'selectCategory',
     payload: { categoryId },
+  };
+}
+
+export function selectRestaurant(restaurantId) {
+  return {
+    type: 'selectRestaurant',
+    payload: { restaurantId },
   };
 }
 
@@ -84,9 +91,9 @@ export function loadRestaurantInfo() {
       return;
     }
 
-    const restaurant = await fetchRestaurantInfo({
+    const restaurantInfo = await fetchRestaurantInfo({
       restaurantId: selectedRestaurant.id,
     });
-    dispatch(setRestaurantInfo(restaurant));
+    dispatch(setRestaurantInfo(restaurantInfo));
   };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -83,17 +83,13 @@ export function loadRestaurants() {
   };
 }
 
-export function loadRestaurantInfo() {
-  return async (dispatch, getState) => {
-    const { selectedRestaurant } = getState();
-
-    if (!selectedRestaurant) {
+export function loadRestaurantInfo(restaurantId) {
+  return async (dispatch) => {
+    if (restaurantId === undefined || restaurantId === null || restaurantId === '') {
       return;
     }
 
-    const restaurantInfo = await fetchRestaurantInfo({
-      restaurantId: selectedRestaurant.id,
-    });
+    const restaurantInfo = await fetchRestaurantInfo({ restaurantId });
     dispatch(setRestaurantInfo(restaurantInfo));
   };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,6 +2,7 @@ import {
   fetchRegions,
   fetchCategories,
   fetchRestaurants,
+  fetchRestaurantInfo,
 } from './services/api';
 
 export function setRegions(regions) {
@@ -22,6 +23,13 @@ export function setRestaurants(restaurants) {
   return {
     type: 'setRestaurants',
     payload: { restaurants },
+  };
+}
+
+export function setRestaurantInfo(restaurant) {
+  return {
+    type: 'setRestaurantInfo',
+    payload: { restaurant },
   };
 }
 
@@ -65,5 +73,20 @@ export function loadRestaurants() {
       categoryId: category.id,
     });
     dispatch(setRestaurants(restaurants));
+  };
+}
+
+export function loadRestaurantInfo() {
+  return async (dispatch, getState) => {
+    const { selectedRestaurant } = getState();
+
+    if (!selectedRestaurant) {
+      return;
+    }
+
+    const restaurant = await fetchRestaurantInfo({
+      restaurantId: selectedRestaurant.id,
+    });
+    dispatch(setRestaurantInfo(restaurant));
   };
 }

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -8,6 +8,8 @@ import {
   setCategories,
   loadRestaurants,
   setRestaurants,
+  loadRestaurantInfo,
+  setRestaurantInfo,
 } from './actions';
 
 const middlewares = [thunk];
@@ -76,6 +78,45 @@ describe('actions', () => {
 
       it('does\'nt run any actions', async () => {
         await store.dispatch(loadRestaurants());
+
+        const actions = store.getActions();
+
+        expect(actions).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('loadRestaurantInfo', () => {
+    context('with restaurantId', () => {
+      beforeEach(() => {
+        store = mockStore({
+          selectedRestaurant: {
+            id: 1,
+            name: '양천주가',
+            address: '서울 강남구 123456',
+            information: '양천주가 in 서울 강남구 123456',
+          },
+        });
+      });
+
+      it('runs setRestaurantInfo', async () => {
+        await store.dispatch(loadRestaurantInfo());
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toEqual(setRestaurantInfo([]));
+      });
+    });
+
+    context('without restaurantId', () => {
+      beforeEach(() => {
+        store = mockStore({
+          selectedRestaurant: null,
+        });
+      });
+
+      it('does\'nt run any actions', async () => {
+        await store.dispatch(loadRestaurantInfo());
 
         const actions = store.getActions();
 

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -89,18 +89,11 @@ describe('actions', () => {
   describe('loadRestaurantInfo', () => {
     context('with restaurantId', () => {
       beforeEach(() => {
-        store = mockStore({
-          selectedRestaurant: {
-            id: 1,
-            name: '양천주가',
-            address: '서울 강남구 123456',
-            information: '양천주가 in 서울 강남구 123456',
-          },
-        });
+        store = mockStore({});
       });
 
       it('runs setRestaurantInfo', async () => {
-        await store.dispatch(loadRestaurantInfo());
+        await store.dispatch(loadRestaurantInfo(1));
 
         const actions = store.getActions();
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 
+import { BrowserRouter } from 'react-router-dom';
+
 import App from './App';
 
 import store from './store';
@@ -10,7 +12,9 @@ import store from './store';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   ),
   document.getElementById('app'),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,6 +6,7 @@ const initialState = {
   restaurants: [],
   selectedRegion: null,
   selectedCategory: null,
+  selectedRestaurant: null,
   restaurantInfo: null,
 };
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -6,6 +6,7 @@ const initialState = {
   restaurants: [],
   selectedRegion: null,
   selectedCategory: null,
+  restaurantInfo: null,
 };
 
 const reducers = {
@@ -30,6 +31,13 @@ const reducers = {
     };
   },
 
+  setRestaurantInfo(state, { payload: { restaurantInfo } }) {
+    return {
+      ...state,
+      restaurantInfo,
+    };
+  },
+
   selectRegion(state, { payload: { regionId } }) {
     const { regions } = state;
     return {
@@ -43,6 +51,14 @@ const reducers = {
     return {
       ...state,
       selectedCategory: categories.find(equal('id', categoryId)),
+    };
+  },
+
+  selectRestaurant(state, { payload: { restaurantId } }) {
+    const { restaurants } = state;
+    return {
+      ...state,
+      selectedRestaurant: restaurants.find(equal('id', restaurantId)),
     };
   },
 };

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -18,6 +18,7 @@ describe('reducer', () => {
       restaurants: [],
       selectedRegion: null,
       selectedCategory: null,
+      selectedRestaurant: null,
       restaurantInfo: null,
     };
 

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -6,6 +6,8 @@ import {
   setRestaurants,
   selectRegion,
   selectCategory,
+  selectRestaurant,
+  setRestaurantInfo,
 } from './actions';
 
 describe('reducer', () => {
@@ -16,6 +18,7 @@ describe('reducer', () => {
       restaurants: [],
       selectedRegion: null,
       selectedCategory: null,
+      restaurantInfo: null,
     };
 
     it('returns initialState', () => {
@@ -106,6 +109,50 @@ describe('reducer', () => {
         id: 1,
         name: '한식',
       });
+    });
+  });
+
+  describe('selectRestaurant', () => {
+    it('changes selected restaurant', () => {
+      const initialState = {
+        restaurants: [
+          {
+            id: 1, name: '김밥제국', category: '분식', address: '서울시 강남구 역삼동',
+          },
+        ],
+        selectedRestaurant: null,
+      };
+
+      const state = reducer(initialState, selectRestaurant(1));
+
+      expect(state.selectedRestaurant).toEqual({
+        id: 1, name: '김밥제국', category: '분식', address: '서울시 강남구 역삼동',
+      });
+    });
+  });
+
+  describe('setRestaurantInfo', () => {
+    it('changes restaurant info', () => {
+      const initialState = {
+        restaurantInfo: null,
+      };
+
+      const restaurantInfo = {
+        id: 1,
+        name: '양천주가',
+        address: '서울 강남구 123456',
+        menuItems: [
+          {
+            id: 1,
+            restaurantId: 1,
+            name: '비빔밥',
+          },
+        ],
+      };
+
+      const state = reducer(initialState, setRestaurantInfo(restaurantInfo));
+
+      expect(state.restaurantInfo).toEqual(restaurantInfo);
     });
   });
 });

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -9,3 +9,7 @@ export async function fetchCategories() {
 export async function fetchRestaurants() {
   return [];
 }
+
+export async function fetchRestaurantInfo() {
+  return [];
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -19,3 +19,11 @@ export async function fetchRestaurants({ regionName, categoryId }) {
   const data = await response.json();
   return data;
 }
+
+export async function fetchRestaurantInfo({ restaurantId }) {
+  const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
+    + `${restaurantId}`;
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -22,7 +22,7 @@ export async function fetchRestaurants({ regionName, categoryId }) {
 
 export async function fetchRestaurantInfo({ restaurantId }) {
   const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
-    + `${restaurantId}`;
+    + `/${restaurantId}`;
   const response = await fetch(url);
   const data = await response.json();
   return data;

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -8,7 +8,7 @@ import {
 import REGIONS from '../../fixtures/regions';
 import CATEGORIES from '../../fixtures/categories';
 import RESTAURANTS from '../../fixtures/restaurants';
-import RESTAURANT from '../../fixtures/restaurant';
+import RESTAURANTINFO from '../../fixtures/restaurantInfo';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -58,13 +58,13 @@ describe('api', () => {
 
   describe('fetchRestaurant', () => {
     beforeEach(() => {
-      mockFetch(RESTAURANT);
+      mockFetch(RESTAURANTINFO);
     });
 
     it('returns restaurants', async () => {
       const restaurant = await fetchRestaurantInfo({ restaurantId: 1 });
 
-      expect(restaurant).toEqual(RESTAURANT);
+      expect(restaurant).toEqual(RESTAURANTINFO);
     });
   });
 });

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,8 +1,14 @@
-import { fetchRegions, fetchCategories, fetchRestaurants } from './api';
+import {
+  fetchRegions,
+  fetchCategories,
+  fetchRestaurants,
+  fetchRestaurantInfo,
+} from './api';
 
 import REGIONS from '../../fixtures/regions';
 import CATEGORIES from '../../fixtures/categories';
 import RESTAURANTS from '../../fixtures/restaurants';
+import RESTAURANT from '../../fixtures/restaurant';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -47,6 +53,18 @@ describe('api', () => {
       });
 
       expect(restaurants).toEqual(RESTAURANTS);
+    });
+  });
+
+  describe('fetchRestaurant', () => {
+    beforeEach(() => {
+      mockFetch(RESTAURANT);
+    });
+
+    it('returns restaurants', async () => {
+      const restaurant = await fetchRestaurantInfo({ restaurantId: 1 });
+
+      expect(restaurant).toEqual(RESTAURANT);
     });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,4 +14,9 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+  devServer: {
+    historyApiFallback: {
+      index: 'index.html',
+    },
+  },
 };


### PR DESCRIPTION
6주차 과제 제출합니다.

## 진행상황

### 2020.03.04(목)

* 헤더 TDD로 구현
* HomePage TDD로 구현
* AboutPage TDD로 구현
* Restaurants TDD로 구현
* RestaurantInfo TDD로 구현

### 2020.03.05(금)

* NotFoundPage TDD로 구현

### 2020.03.06(토)

* 레스토랑 이름을 클릭하면 레스토랑 상세 정보를 가져오던 것을 레스토랑 상세 페이지의 책임으로 전부 옮긴다.
* CSR 렌더링 원리에 따라 `<script src="main.js"></script>`가 아니라 `<script src="/main.js"></script>`으로 absolute path로 설정한다.

## TODO

## 궁금한 점

## 코드 리뷰 모음

## 메타인지

### 내가 모르는 것은 무엇인가

* `localhost:8080/restaurants/:restaurantId`으로 직접 접속하면 오류가 발생하는 이유

### 내가 알게 된 것은 무엇인가

* `localhost:8080/restaurants/:restaurantId`으로 직접 접속하면 오류가 발생하는 이유
  * react router는 CSR을 한다. CSR은 처음에 static files를 모두 가져오고 나서 url을 클라이언트 사이드에서 처리한다. 그런데 만약 static files(특히 main.js)를 가져오지 못한 상태에서 url을 처리하려고 하면 아직 static files가 없고, static files가 없다는 건 react router도 없는 것이므로 라우팅 처리에서 오류가 발생한다. 이를 해결하려면 웹팩 설정에서 `historyApiFallback: true`로 설정해서 없는 주소는 `index.html`로 리다이렉트하도록 한다. 이때 `index.html` 파일은 `main.js` 스크립트를 가져오므로 react router가 포함된 static file을 로딩하게 되서 문제가 해결된다. 단, 이때 `main.js` 파일을 가져올 때 relative path가 아니라 absolute path를 지정해야 한다. 예를 들어, 처음에 `localhost:8080/restaurants/1`로 접속을 하면 웹팩에서 historyApiFallback 설정으로 `index.html`로 리다이렉트 시키는데 이때 relative path로 스크립트 경로가 지정되어 있으면 `localhost:8080/restaurants/1/main.js`로 로딩하려고 하여 파일을 찾지 못하고 404 Not found 오류를 발생시킨다. absolute path로 지정해야 `localhost:8080/main.js`와 같이 정상적인 경로로 스크립트를 로딩한다.

### 어떻게 하면 더 나을까
 
## 읽은 글

* [stackoverflow - react-router urls dont' work when refreshing or writing manually](https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writing-manually)
* [Fixing the 'cannot GET /URL' error on refresh with React Router (or how client side routers work)](https://ui.dev/react-router-cannot-get-url-refresh/)
* [codesoom slack - url을 직접 입력하면 404가 뜨는 문제](https://codesoom-group.slack.com/archives/C01JEHR319T/p1614692515012800)

## 주간회고

[6주차 회고](https://www.notion.so/jayday/6-afa67e02ed074de0a7c6df465730add8)