### PR TITLE
6주차 - 레스토랑 상세 페이지 구현하기

### DIFF
--- a/fixtures/restaurantInfo.js
+++ b/fixtures/restaurantInfo.js
@@ -1,0 +1,12 @@
+const restaurantInfo = {
+  id: 1,
+  category: 1,
+  name: '양천주가',
+  address: '서울시 강남구',
+  menuItems: [
+    { id: 1, restaurantId: 1, name: '비빔밥' },
+    { id: 2, restaurantId: 1, name: '탕수육' },
+  ],
+};
+
+export default restaurantInfo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.4",
+        "react-router-dom": "^6.4.3",
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0"
       },
@@ -2210,6 +2211,14 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
       "dev": true
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.2",
@@ -12617,6 +12626,36 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -18485,6 +18524,11 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
       "dev": true
+    },
+    "@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q=="
     },
     "@sideway/address": {
       "version": "4.1.2",
@@ -26599,6 +26643,23 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.13.1"
+      }
+    },
+    "react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "requires": {
+        "@remix-run/router": "1.0.3"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "requires": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
+    "react-router-dom": "^6.4.3",
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="main.js"></script>
+    <script src="/main.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="UTF-8">
     <title>Demo</title>
+    <base href="/">
   </head>
   <body>
     <div id="app"></div>
-    <script src="/main.js"></script>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/src/AboutPage.jsx
+++ b/src/AboutPage.jsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div>
+      <h2>About</h2>
+      <p>About 페이지입니다</p>
+    </div>
+  );
+}

--- a/src/AboutPage.test.jsx
+++ b/src/AboutPage.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import AboutPage from './AboutPage';
+
+test('AboutPage', () => {
+  render((<AboutPage />));
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,32 +1,21 @@
-import { useEffect } from 'react';
+import { Link, Route, Routes } from 'react-router-dom';
 
-import { useDispatch } from 'react-redux';
-
-import RegionsContainer from './RegionsContainer';
-import CategoriesContainer from './CategoriesContainer';
-import RestaurantsContainer from './RestaurantsContainer';
-
-import {
-  loadInitialData,
-} from './actions';
-
-// 0. 지역, 분류 목록을 얻기
-// 1. 지역 선택 - Regions <- API (0)
-// 2. 분류 선택 - Categories - 한식, 중식, 일식, ... <- API (0)
-// 3. 식당 목록 - Restaurants <- API (with region, category) -> 1, 2 모두 완료된 경우
+import HomePage from './HomePage';
+import AboutPage from '../../restaurant-routing-demo/src/AboutPage';
+import RestaurantsPage from './RestaurantsPage';
 
 export default function App() {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(loadInitialData());
-  });
-
   return (
     <div>
-      <RegionsContainer />
-      <CategoriesContainer />
-      <RestaurantsContainer />
+      <header>
+        <Link to="/">헤더</Link>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/restaurants" element={<RestaurantsPage />} />
+          <Route path="*" element={<HomePage />} />
+        </Routes>
+      </header>
     </div>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ export default function App() {
       <header>
         <Link to="/">헤더</Link>
         <Routes>
-          <Route exact path="/" element={<HomePage />} />
+          <Route path="/" element={<HomePage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/restaurants" element={<RestaurantsPage />} />
           <Route path="/restaurants/:id" element={<RestaurantsInfoPage />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
 import RestaurantsInfoPage from './RestaurantsInfoPage';
+import NotFoundPage from './NotFoundPage';
 
 export default function App() {
   return (
@@ -15,7 +16,7 @@ export default function App() {
           <Route path="/about" element={<AboutPage />} />
           <Route path="/restaurants" element={<RestaurantsPage />} />
           <Route path="/restaurants/:id" element={<RestaurantsInfoPage />} />
-          <Route path="*" element={<HomePage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </header>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { Link, Route, Routes } from 'react-router-dom';
 
 import HomePage from './HomePage';
-import AboutPage from '../../restaurant-routing-demo/src/AboutPage';
+import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
 
 export default function App() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { Link, Route, Routes } from 'react-router-dom';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
 import RestaurantsPage from './RestaurantsPage';
+import RestaurantsInfoPage from './RestaurantsInfoPage';
 
 export default function App() {
   return (
@@ -10,9 +11,10 @@ export default function App() {
       <header>
         <Link to="/">헤더</Link>
         <Routes>
-          <Route path="/" element={<HomePage />} />
+          <Route exact path="/" element={<HomePage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/restaurants" element={<RestaurantsPage />} />
+          <Route path="/restaurants/:id" element={<RestaurantsInfoPage />} />
           <Route path="*" element={<HomePage />} />
         </Routes>
       </header>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,31 +4,50 @@ import { render } from '@testing-library/react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import App from './App';
 
-test('App', () => {
-  const dispatch = jest.fn();
+import restaurants from '../fixtures/restaurants';
+import categories from '../fixtures/categories';
+import regions from '../fixtures/regions';
 
-  useDispatch.mockImplementation(() => dispatch);
+describe('App', () => {
+  beforeEach(() => {
+    const dispatch = jest.fn();
 
-  useSelector.mockImplementation((selector) => selector({
-    regions: [
-      { id: 1, name: '서울' },
-    ],
-    categories: [
-      { id: 1, name: '한식' },
-    ],
-    restaurants: [
-      { id: 1, name: '마법사주방' },
-    ],
-  }));
+    useDispatch.mockImplementation(() => dispatch);
 
-  const { queryByText } = render((
-    <App />
+    useSelector.mockImplementation((selector) => selector({
+      regions,
+      categories,
+      restaurants,
+    }));
+  });
+
+  const renderApp = ({ path }) => render((
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>
   ));
 
-  expect(dispatch).toBeCalled();
+  context('올바른 경로를 가지고 있을 때', () => {
+    it('"/"일 때, 홈페이지를 랜더링한다', () => {
+      const { container } = renderApp({ path: '/' });
 
-  expect(queryByText('서울')).not.toBeNull();
-  expect(queryByText('한식')).not.toBeNull();
+      expect(container).toHaveTextContent('Home');
+    });
+
+    it('"/about"일 때, about 페이지를 랜더링한다', () => {
+      const { container } = renderApp({ path: '/about' });
+
+      expect(container).toHaveTextContent('About');
+    });
+
+    it('"/restaurants"일 때, 레스토랑 페이지를 랜더링한다', () => {
+      const { container } = renderApp({ path: '/restaurants' });
+
+      expect(container).toHaveTextContent('마법사주방');
+    });
+  });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -41,7 +41,7 @@ describe('App', () => {
     it('"/about"일 때, about 페이지를 랜더링한다', () => {
       const { container } = renderApp({ path: '/about' });
 
-      expect(container).toHaveTextContent('영국에서');
+      expect(container).toHaveTextContent('About 페이지입니다');
     });
 
     it('"/restaurants"일 때, 레스토랑 페이지를 랜더링한다', () => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -41,13 +41,13 @@ describe('App', () => {
     it('"/about"일 때, about 페이지를 랜더링한다', () => {
       const { container } = renderApp({ path: '/about' });
 
-      expect(container).toHaveTextContent('About');
+      expect(container).toHaveTextContent('영국에서');
     });
 
     it('"/restaurants"일 때, 레스토랑 페이지를 랜더링한다', () => {
       const { container } = renderApp({ path: '/restaurants' });
 
-      expect(container).toHaveTextContent('마법사주방');
+      expect(container).toHaveTextContent('김밥제국');
     });
   });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -50,4 +50,12 @@ describe('App', () => {
       expect(container).toHaveTextContent('김밥제국');
     });
   });
+
+  context('잘못된 경로를 가지고 있을 때', () => {
+    it('NotFoundPage로 연결된다', () => {
+      const { container } = renderApp({ path: '/xxx' });
+
+      expect(container).toHaveTextContent('404 Not Found');
+    });
+  });
 });

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h2>Home</h2>
+      <ul>
+        <li>
+          <Link to="/about">About</Link>
+        </li>
+        <li>
+          <Link to="/restaurants">Restaurants</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -2,8 +2,14 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import HomePage from './HomePage';
 
 test('HomePage', () => {
-  render((<HomePage />));
+  render((
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>
+  ));
 });

--- a/src/HomePage.test.jsx
+++ b/src/HomePage.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import HomePage from './HomePage';
+
+test('HomePage', () => {
+  render((<HomePage />));
+});

--- a/src/NotFoundPage.jsx
+++ b/src/NotFoundPage.jsx
@@ -1,0 +1,7 @@
+export default function NotFoundPage() {
+  return (
+    <div>
+      <h2>404 Not Found</h2>
+    </div>
+  );
+}

--- a/src/NotFoundPage.test.jsx
+++ b/src/NotFoundPage.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import NotFoundPage from './NotFoundPage';
+
+test('NotFoundPage', () => {
+  render((<NotFoundPage />));
+});

--- a/src/RestaurantDetail.jsx
+++ b/src/RestaurantDetail.jsx
@@ -1,0 +1,18 @@
+import RestaurantMenuItem from './RestaurantMenuItem';
+
+export default function RestaurantDetail({ restaurantInfo }) {
+  const { name, address, menuItems } = restaurantInfo;
+
+  return (
+    <div>
+      <h2>{name}</h2>
+      <p>
+        주소 :
+        {' '}
+        {address}
+      </p>
+      <h3>메뉴 : </h3>
+      <RestaurantMenuItem menuItems={menuItems} />
+    </div>
+  );
+}

--- a/src/RestaurantDetail.test.jsx
+++ b/src/RestaurantDetail.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import RestaurantDetail from './RestaurantDetail';
+
+import RESTAURANT_INFO from '../fixtures/restaurantInfo';
+
+describe('RestaurantDetail', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
+
+  const renderRestaurantDetail = (restaurantInfo) => render((
+    <RestaurantDetail restaurantInfo={restaurantInfo} />
+  ));
+
+  it('레스토랑 정보가 랜더링된다', () => {
+    useSelector.mockImplementation((selector) => selector({
+      restaurantInfo: RESTAURANT_INFO,
+    }));
+
+    const { queryByText } = renderRestaurantDetail(RESTAURANT_INFO);
+
+    expect(queryByText(/양천주가/)).not.toBeNull();
+    expect(queryByText(/서울시 강남구/)).not.toBeNull();
+  });
+});

--- a/src/RestaurantMenuItem.jsx
+++ b/src/RestaurantMenuItem.jsx
@@ -1,0 +1,17 @@
+export default function RestaurantMenuItem({ menuItems }) {
+  if (!menuItems || menuItems.length === 0) {
+    return <p>메뉴가 없어요!</p>;
+  }
+
+  return (
+    <ul>
+      {
+        menuItems.map((menuItem) => (
+          <li key={menuItem.id}>
+            {menuItem.name}
+          </li>
+        ))
+      }
+    </ul>
+  );
+}

--- a/src/RestaurantMenuItem.test.jsx
+++ b/src/RestaurantMenuItem.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import RestaurantMenuItem from './RestaurantMenuItem';
+
+import restaurantInfo from '../fixtures/restaurantInfo';
+
+describe('RestaurantMenuItem', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
+
+  const renderRestaurantMenuItem = (menuItems) => render((
+    <RestaurantMenuItem menuItems={menuItems} />
+  ));
+
+  context('메뉴 아이템 데이터가 있을 시', () => {
+    it('메뉴가 랜더링된다', () => {
+      const { menuItems } = restaurantInfo;
+
+      useSelector.mockImplementation((selector) => selector({
+        menuItems,
+      }));
+
+      const { queryByText } = renderRestaurantMenuItem(menuItems);
+
+      expect(queryByText(/비빔밥/)).not.toBeNull();
+      expect(queryByText(/탕수육/)).not.toBeNull();
+    });
+  });
+
+  context('메뉴 아이템 데이터가 없을 시', () => {
+    it('"메뉴가 없어요!" 문구가 랜더링된다', () => {
+      [[], null, undefined].forEach((menuItems) => {
+        const { container } = renderRestaurantMenuItem(menuItems);
+
+        expect(container).toHaveTextContent('메뉴가 없어요!');
+      });
+    });
+  });
+});

--- a/src/RestaurantsContainer.jsx
+++ b/src/RestaurantsContainer.jsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import { get } from './utils';
 
@@ -9,7 +10,9 @@ export default function RestaurantsContainer() {
     <ul>
       {restaurants.map((restaurant) => (
         <li key={restaurant.id}>
-          {restaurant.name}
+          <Link to={`/restaurants/${restaurant.id}`}>
+            {restaurant.name}
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/RestaurantsContainer.test.jsx
+++ b/src/RestaurantsContainer.test.jsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 
 import { useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 
 import RestaurantsContainer from './RestaurantsContainer';
 
@@ -12,7 +13,9 @@ test('RestaurantsContainer', () => {
   }));
 
   const { container } = render((
-    <RestaurantsContainer />
+    <MemoryRouter>
+      <RestaurantsContainer />
+    </MemoryRouter>
   ));
 
   expect(container).toHaveTextContent('마법사주방');

--- a/src/RestaurantsInfoContainer.jsx
+++ b/src/RestaurantsInfoContainer.jsx
@@ -1,13 +1,17 @@
 import { useEffect } from 'react';
 
+import { useParams } from 'react-router-dom';
+
 import { useSelector, useDispatch } from 'react-redux';
 
 import { loadRestaurantsInfo } from './actions';
 
 import RestaurantDetail from './RestaurantDetail';
 
-export default function RestaurantsInfoContainer({ id }) {
+export default function RestaurantsInfoContainer() {
   const dispatch = useDispatch();
+
+  const { id } = useParams();
 
   useEffect(() => {
     dispatch(loadRestaurantsInfo(id));

--- a/src/RestaurantsInfoContainer.jsx
+++ b/src/RestaurantsInfoContainer.jsx
@@ -1,0 +1,23 @@
+export default function RestaurantsInfoContainer({ restaurantInfo }) {
+  console.log(restaurantInfo);
+
+  return (
+    <div>
+      <h2>{restaurantInfo.name}</h2>
+      <p>
+        주소:
+        {' '}
+        {restaurantInfo.address}
+      </p>
+      <ul>
+        {
+          restaurantInfo.menuItems?.map(({ id, name: menuName }) => (
+            <li key={id}>
+              {menuName}
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  );
+}

--- a/src/RestaurantsInfoContainer.jsx
+++ b/src/RestaurantsInfoContainer.jsx
@@ -1,6 +1,18 @@
-import { useSelector } from 'react-redux';
+import { useEffect } from 'react';
 
-export default function RestaurantsInfoContainer() {
+import { useSelector, useDispatch } from 'react-redux';
+
+import { loadRestaurantsInfo } from './actions';
+
+import RestaurantDetail from './RestaurantDetail';
+
+export default function RestaurantsInfoContainer({ id }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadRestaurantsInfo(id));
+  }, [id]);
+
   const { restaurantInfo } = useSelector((state) => ({
     restaurantInfo: state.restaurantInfo,
   }));
@@ -9,26 +21,7 @@ export default function RestaurantsInfoContainer() {
     return <p>Loading...</p>;
   }
 
-  const { name, address, menuItems } = restaurantInfo;
-
   return (
-    <div>
-      <h2>{name}</h2>
-      <p>
-        주소:
-        {' '}
-        {address}
-      </p>
-      <h3>메뉴</h3>
-      <ul>
-        {
-          menuItems?.map(({ id, name: menuName }) => (
-            <li key={id}>
-              {menuName}
-            </li>
-          ))
-        }
-      </ul>
-    </div>
+    <RestaurantDetail restaurantInfo={restaurantInfo} />
   );
 }

--- a/src/RestaurantsInfoContainer.jsx
+++ b/src/RestaurantsInfoContainer.jsx
@@ -1,17 +1,28 @@
-export default function RestaurantsInfoContainer({ restaurantInfo }) {
-  console.log(restaurantInfo);
+import { useSelector } from 'react-redux';
+
+export default function RestaurantsInfoContainer() {
+  const { restaurantInfo } = useSelector((state) => ({
+    restaurantInfo: state.restaurantInfo,
+  }));
+
+  if (!restaurantInfo) {
+    return <p>Loading...</p>;
+  }
+
+  const { name, address, menuItems } = restaurantInfo;
 
   return (
     <div>
-      <h2>{restaurantInfo.name}</h2>
+      <h2>{name}</h2>
       <p>
         주소:
         {' '}
-        {restaurantInfo.address}
+        {address}
       </p>
+      <h3>메뉴</h3>
       <ul>
         {
-          restaurantInfo.menuItems?.map(({ id, name: menuName }) => (
+          menuItems?.map(({ id, name: menuName }) => (
             <li key={id}>
               {menuName}
             </li>

--- a/src/RestaurantsInfoContainer.test.jsx
+++ b/src/RestaurantsInfoContainer.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { render } from '@testing-library/react';
 
@@ -9,17 +9,25 @@ import RestaurantsInfoContainer from './RestaurantsInfoContainer';
 import restaurantInfo from '../fixtures/restaurantInfo';
 
 describe('RestaurantsInfoContainer', () => {
-  const renderRestaurantInfoContainer = () => render((
-    <RestaurantsInfoContainer />
+  beforeEach(() => {
+    const dispatch = jest.fn();
+
+    useDispatch.mockImplementation(() => dispatch);
+
+    useSelector.mockImplementation((selector) => selector({
+      restaurantInfo,
+    }));
+  });
+
+  const renderRestaurantInfoContainer = (id) => render((
+    <RestaurantsInfoContainer
+      id={id}
+    />
   ));
 
   context('레스토랑 데이터가 있을 시', () => {
     it('레스토랑 정보가 랜더링된다', () => {
-      useSelector.mockImplementation((selector) => selector({
-        restaurantInfo,
-      }));
-
-      const { container } = renderRestaurantInfoContainer();
+      const { container } = renderRestaurantInfoContainer(restaurantInfo.id);
 
       expect(container).toHaveTextContent(/양천주가/);
       expect(container).toHaveTextContent('비빔밥');

--- a/src/RestaurantsInfoContainer.test.jsx
+++ b/src/RestaurantsInfoContainer.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import RestaurantsInfoContainer from './RestaurantsInfoContainer';
+
+import restaurantInfo from '../fixtures/restaurantInfo';
+
+describe('RestaurantsInfoContainer', () => {
+  const renderRestaurantInfoContainer = () => render((
+    <RestaurantsInfoContainer />
+  ));
+
+  context('레스토랑 데이터가 있을 시', () => {
+    it('레스토랑 정보가 랜더링된다', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo,
+      }));
+
+      const { container } = renderRestaurantInfoContainer();
+
+      expect(container).toHaveTextContent(/양천주가/);
+      expect(container).toHaveTextContent('비빔밥');
+    });
+  });
+
+  context('레스토랑 데이터가 없을 시', () => {
+    it('로딩 문구가 랜더링된다', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo: null,
+      }));
+
+      const { container } = renderRestaurantInfoContainer();
+
+      expect(container).toHaveTextContent('Loading...');
+    });
+  });
+});

--- a/src/RestaurantsInfoPage.jsx
+++ b/src/RestaurantsInfoPage.jsx
@@ -1,23 +1,11 @@
-import { useEffect } from 'react';
-
-import { useDispatch } from 'react-redux';
-
 import { useParams } from 'react-router-dom';
-
-import { loadRestaurantsInfo } from './actions';
 
 import RestaurantsInfoContainer from './RestaurantsInfoContainer';
 
 export default function RestaurantsInfoPage() {
-  const dispatch = useDispatch();
-
   const { id } = useParams();
 
-  useEffect(() => {
-    dispatch(loadRestaurantsInfo(id));
-  }, [id]);
-
   return (
-    <RestaurantsInfoContainer />
+    <RestaurantsInfoContainer id={id} />
   );
 }

--- a/src/RestaurantsInfoPage.jsx
+++ b/src/RestaurantsInfoPage.jsx
@@ -1,11 +1,7 @@
-import { useParams } from 'react-router-dom';
-
 import RestaurantsInfoContainer from './RestaurantsInfoContainer';
 
 export default function RestaurantsInfoPage() {
-  const { id } = useParams();
-
   return (
-    <RestaurantsInfoContainer id={id} />
+    <RestaurantsInfoContainer />
   );
 }

--- a/src/RestaurantsInfoPage.jsx
+++ b/src/RestaurantsInfoPage.jsx
@@ -15,7 +15,7 @@ export default function RestaurantsInfoPage() {
 
   useEffect(() => {
     dispatch(loadRestaurantsInfo(id));
-  }, []);
+  }, [id]);
 
   return (
     <RestaurantsInfoContainer />

--- a/src/RestaurantsInfoPage.jsx
+++ b/src/RestaurantsInfoPage.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useParams } from 'react-router-dom';
+
+import { loadRestaurantsInfo } from './actions';
+
+import RestaurantsInfoContainer from './RestaurantsInfoContainer';
+
+export default function RestaurantsInfoPage() {
+  const dispatch = useDispatch();
+
+  const { id } = useParams();
+
+  useEffect(() => {
+    dispatch(loadRestaurantsInfo(id));
+  }, []);
+
+  const restaurantInfo = useSelector((state) => ({
+    restaurantInfo: state.restaurantInfo,
+  }));
+
+  return (
+    <RestaurantsInfoContainer
+      restaurantInfo={restaurantInfo}
+    />
+  );
+}

--- a/src/RestaurantsInfoPage.jsx
+++ b/src/RestaurantsInfoPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useParams } from 'react-router-dom';
 
@@ -17,13 +17,7 @@ export default function RestaurantsInfoPage() {
     dispatch(loadRestaurantsInfo(id));
   }, []);
 
-  const restaurantInfo = useSelector((state) => ({
-    restaurantInfo: state.restaurantInfo,
-  }));
-
   return (
-    <RestaurantsInfoContainer
-      restaurantInfo={restaurantInfo}
-    />
+    <RestaurantsInfoContainer />
   );
 }

--- a/src/RestaurantsInfoPage.test.jsx
+++ b/src/RestaurantsInfoPage.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import RestaurantsInfoPage from './RestaurantsInfoPage';
+
+import restaurantInfo from '../fixtures/restaurantInfo';
+
+describe('RestaurantsInfoPage', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
+
+  const renderRestaurantInfoPage = (pathname) => render((
+    <MemoryRouter initialEntries={[pathname]}>
+      <Routes>
+        <Route path="/restaurants/:id" element={<RestaurantsInfoPage />} />
+      </Routes>
+    </MemoryRouter>
+  ));
+
+  context('레스토랑 데이터가 있을 시', () => {
+    it('레스토랑 정보가 랜더링된다', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo,
+      }));
+
+      const { queryByText } = renderRestaurantInfoPage('/restaurants/1');
+
+      expect(dispatch).toBeCalled();
+
+      expect(queryByText(/양천주가/)).not.toBeNull();
+    });
+  });
+
+  context('레스토랑 데이터가 없을 시', () => {
+    it('로딩 문구가 랜더링된다', () => {
+      useSelector.mockImplementation((selector) => selector({
+        restaurantInfo: null,
+      }));
+
+      const { container } = renderRestaurantInfoPage('/restaurants/-1');
+
+      expect(dispatch).toBeCalled();
+
+      expect(container).toHaveTextContent('Loading...');
+    });
+  });
+});

--- a/src/RestaurantsPage.jsx
+++ b/src/RestaurantsPage.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import RegionsContainer from './RegionsContainer';
+import CategoriesContainer from './CategoriesContainer';
+import RestaurantsContainer from './RestaurantsContainer';
+
+import {
+  loadInitialData,
+} from './actions';
+
+export default function RestaurantsPage() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(loadInitialData());
+  });
+
+  return (
+    <div>
+      <RegionsContainer />
+      <CategoriesContainer />
+      <RestaurantsContainer />
+    </div>
+  );
+}

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { render } from '@testing-library/react';
+
+import RestaurantsPage from './RestaurantsPage';
+
+import regions from '../fixtures/regions';
+import categories from '../fixtures/categories';
+import restaurants from '../fixtures/restaurants';
+
+test('RestaurantsPage', () => {
+  const dispatch = jest.fn();
+
+  useDispatch.mockImplementation(() => dispatch);
+
+  useSelector.mockImplementation((selector) => selector({
+    regions,
+    categories,
+    restaurants,
+  }));
+
+  const { queryByText } = render((
+    <RestaurantsPage />
+  ));
+
+  expect(dispatch).toBeCalled();
+
+  expect(queryByText('서울')).not.toBeNull();
+  expect(queryByText('한식')).not.toBeNull();
+  expect(queryByText('김밥천국')).not.toBeNull();
+});

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -29,5 +29,5 @@ test('RestaurantsPage', () => {
 
   expect(queryByText('서울')).not.toBeNull();
   expect(queryByText('한식')).not.toBeNull();
-  expect(queryByText('김밥천국')).not.toBeNull();
+  expect(queryByText('김밥제국')).not.toBeNull();
 });

--- a/src/RestaurantsPage.test.jsx
+++ b/src/RestaurantsPage.test.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { render } from '@testing-library/react';
 
+import { MemoryRouter } from 'react-router-dom';
 import RestaurantsPage from './RestaurantsPage';
 
 import regions from '../fixtures/regions';
@@ -22,7 +23,9 @@ test('RestaurantsPage', () => {
   }));
 
   const { queryByText } = render((
-    <RestaurantsPage />
+    <MemoryRouter>
+      <RestaurantsPage />
+    </MemoryRouter>
   ));
 
   expect(dispatch).toBeCalled();

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,6 +2,7 @@ import {
   fetchRegions,
   fetchCategories,
   fetchRestaurants,
+  fetchRestaurantInfo,
 } from './services/api';
 
 export function setRegions(regions) {
@@ -22,6 +23,13 @@ export function setRestaurants(restaurants) {
   return {
     type: 'setRestaurants',
     payload: { restaurants },
+  };
+}
+
+export function setRestaurantInfo(restaurantInfo) {
+  return {
+    type: 'setRestaurantInfo',
+    payload: { restaurantInfo },
   };
 }
 
@@ -51,10 +59,7 @@ export function loadInitialData() {
 
 export function loadRestaurants() {
   return async (dispatch, getState) => {
-    const {
-      selectedRegion: region,
-      selectedCategory: category,
-    } = getState();
+    const { selectedRegion: region, selectedCategory: category } = getState();
 
     if (!region || !category) {
       return;
@@ -65,5 +70,13 @@ export function loadRestaurants() {
       categoryId: category.id,
     });
     dispatch(setRestaurants(restaurants));
+  };
+}
+
+export function loadRestaurantsInfo(restaurantId) {
+  return async (dispatch) => {
+    const restaurantInfo = await fetchRestaurantInfo(restaurantId);
+
+    dispatch(setRestaurantInfo(restaurantInfo));
   };
 }

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -2,12 +2,16 @@ import thunk from 'redux-thunk';
 
 import configureStore from 'redux-mock-store';
 
+import restaurantInfo from '../fixtures/restaurantInfo';
+
 import {
   loadInitialData,
   setRegions,
   setCategories,
   loadRestaurants,
   setRestaurants,
+  loadRestaurantsInfo,
+  setRestaurantInfo,
 } from './actions';
 
 const middlewares = [thunk];
@@ -58,7 +62,7 @@ describe('actions', () => {
         });
       });
 
-      it('does\'nt run any actions', async () => {
+      it("does'nt run any actions", async () => {
         await store.dispatch(loadRestaurants());
 
         const actions = store.getActions();
@@ -74,13 +78,29 @@ describe('actions', () => {
         });
       });
 
-      it('does\'nt run any actions', async () => {
+      it("does'nt run any actions", async () => {
         await store.dispatch(loadRestaurants());
 
         const actions = store.getActions();
 
         expect(actions).toHaveLength(0);
       });
+    });
+  });
+
+  describe('loadRestaurantsInfo', () => {
+    beforeEach(() => {
+      store = mockStore({
+        restaurantInfo,
+      });
+    });
+
+    it('setRestaurantInfo을 실행시킨다', async () => {
+      await store.dispatch(loadRestaurantsInfo());
+
+      const actions = store.getActions();
+
+      expect(actions[0]).toEqual(setRestaurantInfo([]));
     });
   });
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,8 @@ import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 
+import { BrowserRouter } from 'react-router-dom';
+
 import App from './App';
 
 import store from './store';
@@ -9,7 +11,9 @@ import store from './store';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   ),
   document.getElementById('app'),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -4,6 +4,7 @@ const initialState = {
   regions: [],
   categories: [],
   restaurants: [],
+  restaurantInfo: null,
   selectedRegion: null,
   selectedCategory: null,
 };
@@ -27,6 +28,13 @@ const reducers = {
     return {
       ...state,
       restaurants,
+    };
+  },
+
+  setRestaurantInfo(state, { payload: { restaurantInfo } }) {
+    return {
+      ...state,
+      restaurantInfo,
     };
   },
 

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -14,6 +14,7 @@ describe('reducer', () => {
       regions: [],
       categories: [],
       restaurants: [],
+      restaurantInfo: null,
       selectedRegion: null,
       selectedCategory: null,
     };
@@ -31,9 +32,7 @@ describe('reducer', () => {
         regions: [],
       };
 
-      const regions = [
-        { id: 1, name: '서울' },
-      ];
+      const regions = [{ id: 1, name: '서울' }];
 
       const state = reducer(initialState, setRegions(regions));
 
@@ -47,9 +46,7 @@ describe('reducer', () => {
         categories: [],
       };
 
-      const categories = [
-        { id: 1, name: '한식' },
-      ];
+      const categories = [{ id: 1, name: '한식' }];
 
       const state = reducer(initialState, setCategories(categories));
 
@@ -63,9 +60,7 @@ describe('reducer', () => {
         restaurants: [],
       };
 
-      const restaurants = [
-        { id: 1, name: '마법사주방' },
-      ];
+      const restaurants = [{ id: 1, name: '마법사주방' }];
 
       const state = reducer(initialState, setRestaurants(restaurants));
 
@@ -76,9 +71,7 @@ describe('reducer', () => {
   describe('selectRegion', () => {
     it('changes selected region', () => {
       const initialState = {
-        regions: [
-          { id: 1, name: '서울' },
-        ],
+        regions: [{ id: 1, name: '서울' }],
         selectedRegion: null,
       };
 
@@ -94,9 +87,7 @@ describe('reducer', () => {
   describe('selectCategory', () => {
     it('changes selected category', () => {
       const initialState = {
-        categories: [
-          { id: 1, name: '한식' },
-        ],
+        categories: [{ id: 1, name: '한식' }],
         selectedCategory: null,
       };
 

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -4,9 +4,12 @@ import {
   setRegions,
   setCategories,
   setRestaurants,
+  setRestaurantInfo,
   selectRegion,
   selectCategory,
 } from './actions';
+
+import restaurantInfo from '../fixtures/restaurantInfo';
 
 describe('reducer', () => {
   context('when previous state is undefined', () => {
@@ -65,6 +68,19 @@ describe('reducer', () => {
       const state = reducer(initialState, setRestaurants(restaurants));
 
       expect(state.restaurants).toHaveLength(1);
+    });
+  });
+
+  describe('setRestaurantInfo', () => {
+    it('changes restaurantInfo', () => {
+      const initialState = {
+        restaurantInfo: [],
+      };
+
+      const state = reducer(initialState, setRestaurantInfo(restaurantInfo));
+
+      expect(state.restaurantInfo.name).toBe('양천주가');
+      expect(state.restaurantInfo.address).toBe('서울시 강남구');
     });
   });
 

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -74,7 +74,7 @@ describe('reducer', () => {
   describe('setRestaurantInfo', () => {
     it('changes restaurantInfo', () => {
       const initialState = {
-        restaurantInfo: [],
+        restaurantInfo: null,
       };
 
       const state = reducer(initialState, setRestaurantInfo(restaurantInfo));

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -9,3 +9,7 @@ export async function fetchCategories() {
 export async function fetchRestaurants() {
   return [];
 }
+
+export async function fetchRestaurantInfo() {
+  return [];
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -13,9 +13,8 @@ export async function fetchCategories() {
 }
 
 export async function fetchRestaurants({ regionName, categoryId }) {
-  const url =
-    'https://eatgo-customer-api.ahastudio.com/restaurants' +
-    `?region=${regionName}&category=${categoryId}`;
+  const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
+    + `?region=${regionName}&category=${categoryId}`;
   const response = await fetch(url);
   const data = await response.json();
   return data;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -13,8 +13,16 @@ export async function fetchCategories() {
 }
 
 export async function fetchRestaurants({ regionName, categoryId }) {
-  const url = 'https://eatgo-customer-api.ahastudio.com/restaurants'
-    + `?region=${regionName}&category=${categoryId}`;
+  const url =
+    'https://eatgo-customer-api.ahastudio.com/restaurants' +
+    `?region=${regionName}&category=${categoryId}`;
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}
+
+export async function fetchRestaurantInfo(restaurantId) {
+  const url = `https://eatgo-customer-api.ahastudio.com/restaurants/${restaurantId}`;
   const response = await fetch(url);
   const data = await response.json();
   return data;

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,13 +1,21 @@
-import { fetchRegions, fetchCategories, fetchRestaurants } from './api';
+import {
+  fetchRegions,
+  fetchCategories,
+  fetchRestaurants,
+  fetchRestaurantInfo,
+} from './api';
 
 import REGIONS from '../../fixtures/regions';
 import CATEGORIES from '../../fixtures/categories';
 import RESTAURANTS from '../../fixtures/restaurants';
+import RESTAURANTSINFO from '../../fixtures/restaurantInfo';
 
 describe('api', () => {
   const mockFetch = (data) => {
     global.fetch = jest.fn().mockResolvedValue({
-      async json() { return data; },
+      async json() {
+        return data;
+      },
     });
   };
 
@@ -47,6 +55,18 @@ describe('api', () => {
       });
 
       expect(restaurants).toEqual(RESTAURANTS);
+    });
+  });
+
+  describe('fetchRestaurantInfo', () => {
+    beforeEach(() => {
+      mockFetch(RESTAURANTSINFO);
+    });
+
+    it('레스토랑 정보를 랜더링한다', async () => {
+      const restaurantInfo = await fetchRestaurantInfo();
+
+      expect(restaurantInfo).toEqual(RESTAURANTSINFO);
     });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,4 +14,9 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+  devServer: {
+    historyApiFallback: {
+      index: 'index.html',
+    },
+  },
 };


### PR DESCRIPTION
# 목표
레스토랑 상세 페이지 구현하기

### 구현사항
- [x] Home, About, Restaurants 관심사 분리하여 컴포넌트 만들기
- [x] 각각 페이지 라우팅하기
- [x] 레스토랑 상세 페이지 연결하기

### 진행사항
현재 Home, About, Restaurants 페이지를 각각 라우팅해놓은 상태입니다.
레스토랑의 상세 페이지를 보여줄 수 있도록 어떻게 할지 고민하고 있습니다.
차근차근히 해보도록 하겠습니다👊